### PR TITLE
[Feature] JPA Entity 설계

### DIFF
--- a/src/main/java/com/back/MyBoardBackendApplication.java
+++ b/src/main/java/com/back/MyBoardBackendApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class MyBoardBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/back/MyBoardBackendApplication.java
+++ b/src/main/java/com/back/MyBoardBackendApplication.java
@@ -1,7 +1,8 @@
-package com.back.myboardbackend;
+package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class MyBoardBackendApplication {

--- a/src/main/java/com/back/config/JpaConfig.java
+++ b/src/main/java/com/back/config/JpaConfig.java
@@ -11,6 +11,7 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
+        // TODO: 인증 구현 후 세부 로직 작성
         return () -> Optional.of("kkm");
     }
 

--- a/src/main/java/com/back/config/JpaConfig.java
+++ b/src/main/java/com/back/config/JpaConfig.java
@@ -1,0 +1,17 @@
+package com.back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.of("kkm");
+    }
+
+}

--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -1,0 +1,35 @@
+package com.back.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Article extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // id
+
+    @JoinColumn(name = "userId")
+    @ManyToOne(optional = false)
+    private UserAccount userAccount; // 작성자
+
+    @Column(nullable = false) private String title; // 제목
+    @Column(nullable = false, length = 65535) private String content; // 본문
+
+    @JoinTable(
+            name = "article_hashtag",
+            joinColumns = @JoinColumn(name = "articleId"),
+            inverseJoinColumns = @JoinColumn(name = "hashtagId")
+    )
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private Set<Hashtag> hashtags = new LinkedHashSet<>(); // 해시태그 매핑 테이블(N:M)
+
+}

--- a/src/main/java/com/back/domain/BaseEntity.java
+++ b/src/main/java/com/back/domain/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.back.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false, length = 100, updatable = false)
+    protected String createdBy; // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    protected String modifiedBy; // 수정자
+
+}

--- a/src/main/java/com/back/domain/Comment.java
+++ b/src/main/java/com/back/domain/Comment.java
@@ -1,0 +1,28 @@
+package com.back.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // id
+
+    @JoinColumn(name = "articleId")
+    @ManyToOne(optional = false)
+    private Article article; // 게시글
+
+    @JoinColumn(name = "userId")
+    @ManyToOne(optional = false)
+    private UserAccount userAccount; // 작성자
+
+    @Column private Long parentCommentId; // 부모 댓글 id
+    @Column(nullable = false, length = 500) private String content; // 본문
+
+}

--- a/src/main/java/com/back/domain/Hashtag.java
+++ b/src/main/java/com/back/domain/Hashtag.java
@@ -1,0 +1,25 @@
+package com.back.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Hashtag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // id
+
+    @Column(length = 50, unique = true) private String hashtagName; // 해시태그 이름
+
+    @ManyToMany(mappedBy = "hashtags")
+    private Set<Article> articles = new LinkedHashSet<>(); // 게시글 매핑 테이블(N:M)
+
+}

--- a/src/main/java/com/back/domain/UserAccount.java
+++ b/src/main/java/com/back/domain/UserAccount.java
@@ -1,0 +1,26 @@
+package com.back.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserAccount extends BaseEntity {
+
+    @Id
+    @Column(nullable = false, length = 50)
+    private String userId; // 유저 id
+
+    @Column(nullable = false) private String userPassword; // 패스워드
+    @Column(unique = true, length = 50) private String email; // 이메일
+    @Column(unique = true, length = 50) private String nickname; // 닉네임
+    @Column private String memo; // 메모
+    @Column private String socialProvider; // 소셜 로그인 제공처
+    @Column private String socialId; // 유저 소셜 고유 id
+
+}

--- a/src/main/java/com/back/repository/ArticleRepository.java
+++ b/src/main/java/com/back/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.back.repository;
+
+import com.back.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Integer> {
+}

--- a/src/main/java/com/back/repository/CommentRepository.java
+++ b/src/main/java/com/back/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.back.repository;
+
+import com.back.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
+}

--- a/src/main/java/com/back/repository/HashtagRepository.java
+++ b/src/main/java/com/back/repository/HashtagRepository.java
@@ -1,0 +1,7 @@
+package com.back.repository;
+
+import com.back.domain.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Integer> {
+}

--- a/src/main/java/com/back/repository/UserAccountRepository.java
+++ b/src/main/java/com/back/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.back.repository;
+
+import com.back.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Integer> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,17 @@
 server:
   port: 8080
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:my-board
+  jpa:
+    open-in-view: false
+    defer-datasource-initialization: true
+    hibernate.ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+  sql.init.mode: always
+  h2.console.enabled: true


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #2 , 
> * #16 

## 📝작업 내용
> * #2 에서 설계한 ERD를 기반으로 엔티티를 정의함.
> * 인증이 구현되어 있지 않아 시큐리티 비활성화
![image](https://github.com/user-attachments/assets/4035de1b-32e7-424a-aff6-ce0d89d01f08)
> * 루트 패키지가 불필요하게 길어서 수정함.  `com.back.myboardbackend` => `com.back`
> * 테이블 공통으로 들어가는 필드를 JPA Auditing 기능을 활용함.(인증 구현 후 Auditing 설정 수정)
> * Article - Hashtag 매핑 테이블을 다대다 관계로 구현하여 관계를 설정함.
![image](https://github.com/user-attachments/assets/fe064289-c123-45be-94a0-5553c940da3e)
![image](https://github.com/user-attachments/assets/f563c3ea-4d2c-47d7-88a1-6068d0540f44)

## ⛔️ 종료할 이슈 
> This close #16 

