### PR TITLE
[Feature] JPA 연관관계 매핑 개선(N:M 관계)

### DIFF
--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -5,9 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -17,19 +14,11 @@ public class Article extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // id
 
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "user_id")
     @ManyToOne(optional = false)
     private UserAccount userAccount; // 작성자
 
     @Column(nullable = false) private String title; // 제목
     @Column(nullable = false, length = 65535) private String content; // 본문
-
-    @JoinTable(
-            name = "article_hashtag",
-            joinColumns = @JoinColumn(name = "articleId"),
-            inverseJoinColumns = @JoinColumn(name = "hashtagId")
-    )
-    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private Set<Hashtag> hashtags = new LinkedHashSet<>(); // 해시태그 매핑 테이블(N:M)
 
 }

--- a/src/main/java/com/back/domain/ArticleHashtag.java
+++ b/src/main/java/com/back/domain/ArticleHashtag.java
@@ -8,21 +8,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Comment extends BaseEntity {
-
+public class ArticleHashtag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // id
 
-    @JoinColumn(name = "article_id")
     @ManyToOne(optional = false)
+    @JoinColumn(name = "article_id")
     private Article article; // 게시글
 
-    @JoinColumn(name = "user_id")
     @ManyToOne(optional = false)
-    private UserAccount userAccount; // 작성자
-
-    @Column private Long parentCommentId; // 부모 댓글 id
-    @Column(nullable = false, length = 500) private String content; // 본문
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag; // 해시태그ㅐ
 
 }

--- a/src/main/java/com/back/domain/Hashtag.java
+++ b/src/main/java/com/back/domain/Hashtag.java
@@ -5,9 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -18,8 +15,5 @@ public class Hashtag extends BaseEntity {
     private Long id; // id
 
     @Column(length = 50, unique = true) private String hashtagName; // 해시태그 이름
-
-    @ManyToMany(mappedBy = "hashtags")
-    private Set<Article> articles = new LinkedHashSet<>(); // 게시글 매핑 테이블(N:M)
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #24 

## 📝작업 내용
> *  N:M 관계 개선
>    *  Article - Hashtag 관계가 N:M 관계를 맺고 있었다. 
>    * N:M 관계는 엔티티에 추가적인 정보를 저장할 수 없기 때문에 잘 사용하지 않는 연관 관계 구조이다. 
>    * N:M 관계를 끊고 둘 사이를 연결해주는 엔티티(테이블)을 추가했다.
 
> * FK 네이밍 수정
>   * 일부 FK 네이밍을 지정할 때 JAVA 변수명으로 지정되어 있어서 DB 컬럼명으로 수정함.


## ⛔️ 종료할 이슈 
> This close #24 
