### PR TITLE
[Feature] 게시글 등록 기능

### DIFF
--- a/select.sql
+++ b/select.sql
@@ -1,0 +1,5 @@
+SELECT user_id, user_password,  email, nickname, memo, social_provider, social_id, created_at, created_by, modified_at, modified_by FROM USER_ACCOUNT;
+SELECT id, user_id, title, content, created_at, created_by, modified_at, modified_by FROM ARTICLE;
+SELECT id, article_id, user_id, parent_comment_id, content, created_at, created_by, modified_at, modified_by FROM COMMENT;
+SELECT id, hashtag_name created_at, created_by, modified_at, modified_by FROM HASHTAG;
+SELECT id, article_id, hashtag_id, created_at, created_by, modified_at, modified_by FROM ARTICLE_HASHTAG;

--- a/src/main/java/com/back/controler/ArticleController.java
+++ b/src/main/java/com/back/controler/ArticleController.java
@@ -1,0 +1,36 @@
+package com.back.controler;
+
+import com.back.controler.dto.reponse.ApiResponse;
+import com.back.controler.dto.reponse.ArticleResponse;
+import com.back.controler.dto.request.NewArticleRequest;
+import com.back.secuirty.BoardUserDetails;
+import com.back.service.ArticleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/articles")
+@RestController
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ArticleResponse>> newArticle(
+            @RequestBody @Valid NewArticleRequest request,
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+    ) {
+        return ResponseEntity.ok().body(
+                ApiResponse.okWithData(
+                        articleService.newArticle(request.toDto(boardUserDetails.userId())).toResponse()
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/back/controler/dto/reponse/ArticleResponse.java
+++ b/src/main/java/com/back/controler/dto/reponse/ArticleResponse.java
@@ -1,0 +1,12 @@
+package com.back.controler.dto.reponse;
+
+import java.time.LocalDateTime;
+
+public record ArticleResponse(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+}

--- a/src/main/java/com/back/controler/dto/request/NewArticleRequest.java
+++ b/src/main/java/com/back/controler/dto/request/NewArticleRequest.java
@@ -1,0 +1,18 @@
+package com.back.controler.dto.request;
+
+import com.back.service.dto.ArticleDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Set;
+
+public record NewArticleRequest(
+        @NotBlank(message = "제목을 입력하세요.") String title,
+        @NotBlank(message = "내용을 입력하세요.") String content
+) {
+    public ArticleDto toDto(String userId) {
+        return ArticleDto.of(this.title, this.content, userId);
+    }
+
+}

--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -14,11 +14,23 @@ public class Article extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // id
 
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    @ManyToOne(optional = false)
     private UserAccount userAccount; // 작성자
 
-    @Column(nullable = false) private String title; // 제목
-    @Column(nullable = false, length = 65535) private String content; // 본문
+    @Column(nullable = false)
+    private String title; // 제목
+    @Column(nullable = false, length = 65535)
+    private String content; // 본문
+
+    private Article(UserAccount userAccount, String title, String content) {
+        this.userAccount = userAccount;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static Article newArticle(UserAccount userAccount, String title, String content) {
+        return new Article(userAccount, title, content);
+    }
 
 }

--- a/src/main/java/com/back/domain/ArticleHashtag.java
+++ b/src/main/java/com/back/domain/ArticleHashtag.java
@@ -13,12 +13,21 @@ public class ArticleHashtag extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // id
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
     private Article article; // 게시글
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hashtag_id")
-    private Hashtag hashtag; // 해시태그ㅐ
+    private Hashtag hashtag; // 해시태그
+
+    private ArticleHashtag(Article article, Hashtag hashtag) {
+        this.article = article;
+        this.hashtag = hashtag;
+    }
+
+    public static ArticleHashtag of(Article article, Hashtag hashtag) {
+        return new ArticleHashtag(article, hashtag);
+    }
 
 }

--- a/src/main/java/com/back/domain/Hashtag.java
+++ b/src/main/java/com/back/domain/Hashtag.java
@@ -21,7 +21,7 @@ public class Hashtag extends BaseEntity {
         this.hashtagName = hashtagName;
     }
 
-    public static Hashtag from(String hashtagName) {
+    public static Hashtag newHashtag(String hashtagName) {
         return new Hashtag(hashtagName);
     }
 }

--- a/src/main/java/com/back/domain/Hashtag.java
+++ b/src/main/java/com/back/domain/Hashtag.java
@@ -14,6 +14,14 @@ public class Hashtag extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // id
 
-    @Column(length = 50, unique = true) private String hashtagName; // 해시태그 이름
+    @Column(length = 50, unique = true)
+    private String hashtagName; // 해시태그 이름
 
+    private Hashtag(String hashtagName) {
+        this.hashtagName = hashtagName;
+    }
+
+    public static Hashtag from(String hashtagName) {
+        return new Hashtag(hashtagName);
+    }
 }

--- a/src/main/java/com/back/exception/ErrorCode.java
+++ b/src/main/java/com/back/exception/ErrorCode.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // UserAccount
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다."),
+
     //500 error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/java/com/back/exception/UserNotFoundException.java
+++ b/src/main/java/com/back/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.back.exception;
+
+public class UserNotFoundException extends ApplicationException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/back/repository/ArticleHashtagRepository.java
+++ b/src/main/java/com/back/repository/ArticleHashtagRepository.java
@@ -1,0 +1,7 @@
+package com.back.repository;
+
+import com.back.domain.ArticleHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleHashtagRepository extends JpaRepository<ArticleHashtag, Long> {
+}

--- a/src/main/java/com/back/repository/HashtagRepository.java
+++ b/src/main/java/com/back/repository/HashtagRepository.java
@@ -3,5 +3,9 @@ package com.back.repository;
 import com.back.domain.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.Set;
+
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    Set<Hashtag> findByHashtagNameIn(Set<String> hashtagNames);
 }

--- a/src/main/java/com/back/service/ArticleService.java
+++ b/src/main/java/com/back/service/ArticleService.java
@@ -1,0 +1,40 @@
+package com.back.service;
+
+import com.back.domain.Article;
+import com.back.domain.ArticleHashtag;
+import com.back.domain.Hashtag;
+import com.back.domain.UserAccount;
+import com.back.repository.ArticleHashtagRepository;
+import com.back.repository.ArticleRepository;
+import com.back.service.dto.ArticleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleHashtagRepository articleHashtagRepository;
+    private final HashtagService hashtagService;
+    private final UserAccountService userAccountService;
+
+    public ArticleDto newArticle(ArticleDto articleDto) {
+        UserAccount userAccount = userAccountService.getUserAccount(articleDto.userId());
+        Article article = articleDto.newArticle(userAccount);
+        Article savedArticle = articleRepository.save(article);
+
+        Set<Hashtag> hashtags = hashtagService.extractAndSaveHashtags(articleDto.content());
+
+        hashtags.forEach(hashtag -> {
+            articleHashtagRepository.save(ArticleHashtag.of(savedArticle, hashtag));
+        });
+
+        return ArticleDto.of(savedArticle);
+    }
+
+}

--- a/src/main/java/com/back/service/HashtagExtractor.java
+++ b/src/main/java/com/back/service/HashtagExtractor.java
@@ -1,0 +1,29 @@
+package com.back.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class HashtagExtractor {
+
+    public Set<String> extractHashtagNamesFromContent(String content) {
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
+    }
+
+}

--- a/src/main/java/com/back/service/HashtagService.java
+++ b/src/main/java/com/back/service/HashtagService.java
@@ -37,7 +37,7 @@ public class HashtagService {
         // DB에 없는 새로운 해시태그
         Set<Hashtag> newHashtags = hashtagNamesInContent.stream()
                 .filter(hashtagName -> !exitingHashtagNames.contains(hashtagName))
-                .map(Hashtag::from)
+                .map(Hashtag::newHashtag)
                 .collect(Collectors.toSet());
 
         if (!newHashtags.isEmpty()) {

--- a/src/main/java/com/back/service/HashtagService.java
+++ b/src/main/java/com/back/service/HashtagService.java
@@ -1,0 +1,51 @@
+package com.back.service;
+
+import com.back.domain.Hashtag;
+import com.back.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+    private final HashtagExtractor hashtagExtractor;
+
+    public Set<Hashtag> extractAndSaveHashtags(String content) {
+        // 해시태그 추출
+        Set<String> hashtagNamesInContent = hashtagExtractor.extractHashtagNamesFromContent(content);
+
+        if (hashtagNamesInContent.isEmpty()) {
+            return new HashSet<>();
+        }
+
+        // DB에 있는 해시태그 조회
+        Set<Hashtag> existingHashtags = hashtagRepository.findByHashtagNameIn(hashtagNamesInContent);
+
+        // DB에 저장해야 할 해시태그
+        Set<String> exitingHashtagNames = existingHashtags.stream()
+                .map(Hashtag::getHashtagName)
+                .collect(Collectors.toSet());
+
+        // DB에 없는 새로운 해시태그
+        Set<Hashtag> newHashtags = hashtagNamesInContent.stream()
+                .filter(hashtagName -> !exitingHashtagNames.contains(hashtagName))
+                .map(Hashtag::from)
+                .collect(Collectors.toSet());
+
+        if (!newHashtags.isEmpty()) {
+            hashtagRepository.saveAll(newHashtags); // 새로운 해시태그 저장
+            existingHashtags.addAll(newHashtags);
+        }
+
+        return Set.copyOf(existingHashtags);
+    }
+
+}

--- a/src/main/java/com/back/service/UserAccountService.java
+++ b/src/main/java/com/back/service/UserAccountService.java
@@ -1,0 +1,23 @@
+package com.back.service;
+
+import com.back.domain.UserAccount;
+import com.back.exception.UserNotFoundException;
+import com.back.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserAccountService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Transactional(readOnly = true)
+    public UserAccount getUserAccount(String userId) {
+        return userAccountRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+}

--- a/src/main/java/com/back/service/dto/ArticleDto.java
+++ b/src/main/java/com/back/service/dto/ArticleDto.java
@@ -1,0 +1,54 @@
+package com.back.service.dto;
+
+import com.back.controler.dto.reponse.ArticleResponse;
+import com.back.domain.Article;
+import com.back.domain.UserAccount;
+
+import java.time.LocalDateTime;
+
+
+public record ArticleDto(
+        Long id, // id
+        String title, // 제목
+        String content, // 내용
+        String userId, // 사용자 id
+        LocalDateTime createdAt, // 작성일시
+        String createdBy, // 작성자
+        LocalDateTime modifiedAt, // 수정일시
+        String modifiedBy // 수정자
+) {
+
+    public static ArticleDto of(
+            Long id, String title, String content, String userId,
+            LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy
+    ) {
+        return new ArticleDto(id, title, content, userId, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleDto of(
+            String title, String content, String userId,
+            LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy
+    ) {
+        return of(null, title, content, userId, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleDto of(String title, String content, String userId) {
+        return of(title, content, userId, null, null, null, null);
+    }
+
+    public static ArticleDto of(Article article) {
+        return of(
+                article.getId(), article.getTitle(), article.getContent(), article.getUserAccount().getUserId(),
+                article.getCreatedAt(), article.getCreatedBy(), article.getModifiedAt(), article.getModifiedBy()
+        );
+    }
+
+    public Article newArticle(UserAccount userAccount) {
+        return Article.newArticle(userAccount, this.title, this.content);
+    }
+
+    public ArticleResponse toResponse() {
+        return new ArticleResponse(this.id, this.title, this.content, this.createdAt, this.createdBy);
+    }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,8 @@
+--- user_account
 insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
                           created_by, modified_at, modified_by)
-values ('admin1', '{noop}qwer1234', 'admin1@naver.com', '별빛1', null, 'kakao', 'qdwd12ddd31dwd',
-        'ROLE_ADMIN', '2015-03-17 23:20:26', 'admin1', '2010-03-05 08:28:54', 'admin1');
+values ('admin1', '{noop}qwer1234', 'admin1@naver.com', '별빛1', null, 'kakao', 'qdwd12ddd31dwd', 'ROLE_ADMIN',
+        '2015-03-17 23:20:26', 'admin1', '2010-03-05 08:28:54', 'admin1');
 insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
                           created_by, modified_at, modified_by)
 values ('user1', '{noop}qwer1234', 'user1@google.com', '아기상어5', null, null, null, 'ROLE_USER',
@@ -27,7 +28,8 @@ values ('user1234', '{noop}rTw80xiNO2as', 'user1234@google.com', '야구팬2', n
         'user1234', '2007-01-18 11:24:26', 'user1234');
 insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
                           created_by, modified_at, modified_by)
-values ('account4256', '{noop}0C1SoS29gaD', 'account4256@google.com', '아기상어1', null, 'kakao', 'adw2d12df3vv', 'ROLE_USER',
+values ('account4256', '{noop}0C1SoS29gaD', 'account4256@google.com', '아기상어1', null, 'kakao', 'adw2d12df3vv',
+        'ROLE_USER',
         '2009-07-16 17:59:25', 'account4256', '2013-07-06 03:53:35', 'account4256');
 insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
                           created_by, modified_at, modified_by)
@@ -41,3 +43,48 @@ insert into user_account (user_id, user_password, email, nickname, memo, social_
                           created_by, modified_at, modified_by)
 values ('account4526', '{noop}ukjt0YMye', 'account4526@naver.com', '아기상어2', null, null, null, 'ROLE_USER',
         '2015-05-05 21:44:54', 'account4526', '2018-01-30 14:20:46', 'account4526');
+
+--- article
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('admin1', '우승 예상팀', '우승 예상팀우승 예상팀우승 예상팀우승 예상팀우승 예상팀 #java #jpa', '2005-12-14', 'admin1', '2011-07-28',
+        'admin1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('admin1', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작 #jpa', '2008-07-06', 'admin1',
+        '2004-10-17', 'admin1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('user1', '선수 부상 소식', '선수 부상 소식선수 부상 소식 #spring', '2019-07-28', 'user1', '2008-03-20', 'user1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('user1', '야구 시즌 시작', '세 번째 게시글 내용', '2015-08-06', 'user1', '2012-09-25', 'user1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('account4256', '우승 예상팀', '승 예상팀승 예상팀승 예상팀승 예상팀승 예상팀', '2016-05-03', 'account4256', '2004-02-28',
+        'account4256');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '이적설 확인', '이적설 확인이적설 확인이적설 확인이적설 확인', '2014-07-23', 'player7849', '2001-09-12',
+        'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '팀 승리 기록', '팀 승리 기록팀 승리 기록', '2006-04-28', 'player7849', '2001-04-30', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '우승 예상팀', '우승 예상팀우승 예상팀', '2010-08-20', 'player7849', '2006-02-12', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작', '2014-10-30', 'player7849', '2016-06-27', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작', '2003-08-10', 'player7849', '2008-09-28',
+        'player7849');
+
+--- hashtag
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('#java', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('#jpa', '2007-03-13', 'admin1', '2011-05-21', 'admin1');
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('#spring', '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+
+-- article_hashtag
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (1, 1, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (1, 2, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (2, 2, '2007-03-13', 'admin1', '2011-05-21', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (3, 3, '2013-06-22', 'admin1', '2020-08-04', 'admin1');

--- a/src/test/java/com/back/MyBoardBackendApplicationTests.java
+++ b/src/test/java/com/back/MyBoardBackendApplicationTests.java
@@ -1,4 +1,4 @@
-package com.back.myboardbackend;
+package com.back;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/back/config/JsonDataEncoder.java
+++ b/src/test/java/com/back/config/JsonDataEncoder.java
@@ -1,0 +1,20 @@
+package com.back.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class JsonDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public JsonDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public String encode(Object obj) throws JsonProcessingException {
+        return mapper.writeValueAsString(obj);
+    }
+
+}

--- a/src/test/java/com/back/controler/ArticleControllerTest.java
+++ b/src/test/java/com/back/controler/ArticleControllerTest.java
@@ -1,0 +1,90 @@
+package com.back.controler;
+
+import com.back.config.JsonDataEncoder;
+import com.back.config.SecurityConfig;
+import com.back.controler.dto.request.NewArticleRequest;
+import com.back.exception.UserNotFoundException;
+import com.back.service.ArticleService;
+import com.back.service.dto.ArticleDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.back.controler.dto.request.NewArticleRequestFactory.createDefaultNewArticleRequest;
+import static com.back.service.dto.ArticleDtoFactory.createArticleDto;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@DisplayName("컨트롤러 - 게시글")
+@Import({JsonDataEncoder.class})
+@WebMvcTest(
+        controllers = ArticleController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfig.class
+                ),
+        }
+)
+class ArticleControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private JsonDataEncoder jsonDataEncoder;
+
+    @MockitoBean
+    private ArticleService articleService;
+
+    @DisplayName("게시글 생성 요청 - 성공")
+    @Test
+    void givenNewArticleRequest_whenNewArticle_thenReturns200() throws Exception {
+        // Given
+        NewArticleRequest request = createDefaultNewArticleRequest();
+        ArticleDto articleDto = createArticleDto();
+        given(articleService.newArticle(any(ArticleDto.class))).willReturn(articleDto);
+
+        // When & Then
+        mvc.perform(post("/v1/articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.message").isEmpty());
+        then(articleService).should().newArticle(any(ArticleDto.class));
+    }
+
+    @DisplayName("게시글 생성 요청 - 실패")
+    @Test
+    void givenNewArticleRequest_whenNewArticle_thenReturns4xx() throws Exception {
+        // Given
+        NewArticleRequest request = createDefaultNewArticleRequest();
+        given(articleService.newArticle(any(ArticleDto.class))).willThrow(new UserNotFoundException());
+
+        // When & Then
+        mvc.perform(post("/v1/articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.message").value(new UserNotFoundException().getMessage()));
+        then(articleService).should().newArticle(any(ArticleDto.class));
+    }
+
+}

--- a/src/test/java/com/back/controler/dto/request/NewArticleRequestFactory.java
+++ b/src/test/java/com/back/controler/dto/request/NewArticleRequestFactory.java
@@ -1,0 +1,23 @@
+package com.back.controler.dto.request;
+
+public class NewArticleRequestFactory {
+
+    private static final String DEFAULT_TITLE = "제목1";
+    private static final String DEFAULT_CONTENT = "내용입니다.";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link NewArticleRequest} 객체를 생성합니다.
+     * <ul>
+     *   <li>title: {@link NewArticleRequestFactory#DEFAULT_TITLE}</li>
+     *   <li>content: {@link NewArticleRequestFactory#DEFAULT_CONTENT}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link NewArticleRequest} 객체
+     */
+    public static NewArticleRequest createDefaultNewArticleRequest() {
+        return new NewArticleRequest(DEFAULT_TITLE, DEFAULT_CONTENT);
+    }
+
+}

--- a/src/test/java/com/back/domain/ArticleMockDataFactoryTest.java
+++ b/src/test/java/com/back/domain/ArticleMockDataFactoryTest.java
@@ -1,0 +1,30 @@
+package com.back.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ArticleMockDataFactoryTest {
+
+    private static final String DEFAULT_TITLE = "제목1";
+    private static final String DEFAULT_CONTENT = "내용입니다.";
+
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link Article} 객체를 생성합니다.
+     * <ul>
+     *   <li>id: {@code 1L}</li>
+     *   <li>title: {@link ArticleMockDataFactoryTest#DEFAULT_TITLE}</li>
+     *   <li>content: {@link ArticleMockDataFactoryTest#DEFAULT_CONTENT}</li>
+     *   <li>UserAccount: {@param userAccount}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link Article} 객체
+     */
+    public static Article createDBArticleFromUserAccount(UserAccount userAccount) {
+        Article article = Article.newArticle(userAccount, DEFAULT_TITLE, DEFAULT_CONTENT);
+        ReflectionTestUtils.setField(article, "id", 1L);
+        return article;
+    }
+
+}

--- a/src/test/java/com/back/domain/HashtagMockDataFactory.java
+++ b/src/test/java/com/back/domain/HashtagMockDataFactory.java
@@ -15,7 +15,7 @@ public class HashtagMockDataFactory {
      * @return {@link Hashtag} 객체
      */
     public static Hashtag createHashtagFromHashtagName(String hashtagName) {
-        return Hashtag.from(hashtagName);
+        return Hashtag.newHashtag(hashtagName);
     }
 
     /**
@@ -30,7 +30,7 @@ public class HashtagMockDataFactory {
      * @return {@link Hashtag} 객체
      */
     public static Hashtag createDBHashtagFromIdAndHashtagName(Long id, String hashtagName) {
-        Hashtag hashtag = Hashtag.from(hashtagName);
+        Hashtag hashtag = Hashtag.newHashtag(hashtagName);
         ReflectionTestUtils.setField(hashtag, "id", id);
         return hashtag;
     }

--- a/src/test/java/com/back/domain/HashtagMockDataFactory.java
+++ b/src/test/java/com/back/domain/HashtagMockDataFactory.java
@@ -1,0 +1,38 @@
+package com.back.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class HashtagMockDataFactory {
+
+    /**
+     * <p>
+     * {@link Hashtag} 객체를 생성합니다.
+     * <ul>
+     *   <li>hashtagName: {@param hashtagName}</li>
+     * </ul>
+     * </p>
+     *
+     * @return {@link Hashtag} 객체
+     */
+    public static Hashtag createHashtagFromHashtagName(String hashtagName) {
+        return Hashtag.from(hashtagName);
+    }
+
+    /**
+     * <p>
+     * {@link Hashtag} 객체를 생성합니다.
+     * <ul>
+     *   <li>id: {@code 1L}</li>
+     *   <li>hashtagName: {@param hashtagName}</li>
+     * </ul>
+     * </p>
+     *
+     * @return {@link Hashtag} 객체
+     */
+    public static Hashtag createDBHashtagFromIdAndHashtagName(Long id, String hashtagName) {
+        Hashtag hashtag = Hashtag.from(hashtagName);
+        ReflectionTestUtils.setField(hashtag, "id", id);
+        return hashtag;
+    }
+
+}

--- a/src/test/java/com/back/domain/UserAccountMockDataFactory.java
+++ b/src/test/java/com/back/domain/UserAccountMockDataFactory.java
@@ -1,0 +1,35 @@
+package com.back.domain;
+
+public class UserAccountMockDataFactory {
+
+    private static final String DEFAULT_PASSWORD = "password1";
+    private static final String DEFAULT_EMAIL = "user1@gmail.com";
+    private static final String DEFAULT_NICKNAME = "닉네임1";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link UserAccount} 객체를 생성합니다.
+     * <ul>
+     *   <li>userId: {@param userId}</li>
+     *   <li>password: {@link UserAccountMockDataFactory#DEFAULT_PASSWORD}</li>
+     *   <li>email: {@link UserAccountMockDataFactory#DEFAULT_EMAIL}</li>
+     *   <li>nickname: {@link UserAccountMockDataFactory#DEFAULT_NICKNAME}</li>
+     *   <li>role: {@link UserRoleType#USER}</li>
+     * </ul>
+     * </p>
+     *
+     * @param userId 유저 id
+     * @return 기본값으로 구성된 {@link UserAccount} 객체
+     */
+    public static UserAccount createDBUserAccountFromUserId(String userId) {
+        return UserAccount.of(
+                userId,
+                DEFAULT_PASSWORD,
+                DEFAULT_EMAIL,
+                DEFAULT_NICKNAME,
+                null,
+                UserRoleType.USER
+        );
+    }
+
+}

--- a/src/test/java/com/back/domain/UserAccountMockDataFactory.java
+++ b/src/test/java/com/back/domain/UserAccountMockDataFactory.java
@@ -2,9 +2,35 @@ package com.back.domain;
 
 public class UserAccountMockDataFactory {
 
+    private static final String DEFAULT_USER_ID = "user1";
     private static final String DEFAULT_PASSWORD = "password1";
     private static final String DEFAULT_EMAIL = "user1@gmail.com";
     private static final String DEFAULT_NICKNAME = "닉네임1";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link UserAccount} 객체를 생성합니다.
+     * <ul>
+     *   <li>userId: {@link UserAccountMockDataFactory#DEFAULT_USER_ID}</li>
+     *   <li>password: {@link UserAccountMockDataFactory#DEFAULT_PASSWORD}</li>
+     *   <li>email: {@link UserAccountMockDataFactory#DEFAULT_EMAIL}</li>
+     *   <li>nickname: {@link UserAccountMockDataFactory#DEFAULT_NICKNAME}</li>
+     *   <li>role: {@link UserRoleType#USER}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link UserAccount} 객체
+     */
+    public static UserAccount createDBUserAccount() {
+        return UserAccount.of(
+                DEFAULT_USER_ID,
+                DEFAULT_PASSWORD,
+                DEFAULT_EMAIL,
+                DEFAULT_NICKNAME,
+                null,
+                UserRoleType.USER
+        );
+    }
 
     /**
      * <p>

--- a/src/test/java/com/back/secuirty/BoardUserDetailsServiceTest.java
+++ b/src/test/java/com/back/secuirty/BoardUserDetailsServiceTest.java
@@ -1,7 +1,6 @@
 package com.back.secuirty;
 
 import com.back.domain.UserAccount;
-import com.back.domain.UserRoleType;
 import com.back.repository.UserAccountRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.Optional;
 
+import static com.back.domain.UserAccountMockDataFactory.createDBUserAccount;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,14 +25,16 @@ import static org.mockito.BDDMockito.then;
 @ExtendWith(MockitoExtension.class)
 class BoardUserDetailsServiceTest {
 
-    @InjectMocks private BoardUserDetailsService sut;
-    @Mock private UserAccountRepository userAccountRepository;
+    @InjectMocks
+    private BoardUserDetailsService sut;
+    @Mock
+    private UserAccountRepository userAccountRepository;
 
     @DisplayName("'username' 을 입력하면, 'UserDetails' 를 반환한다.")
     @Test
     void givenUsername_whenLoadUserByUsername_thenReturnsUserDetails() {
         // Given
-        UserAccount userAccount = createUser();
+        UserAccount userAccount = createDBUserAccount();
         given(userAccountRepository.findById(anyString())).willReturn(Optional.of(userAccount));
 
         // When
@@ -59,17 +61,6 @@ class BoardUserDetailsServiceTest {
         // Then
         assertThat(exception).isInstanceOf(UsernameNotFoundException.class);
         then(userAccountRepository).should().findById(anyString());
-    }
-
-    private UserAccount createUser() {
-        return UserAccount.of(
-                "user1",
-                "qwer1234",
-                "user1@naver.com",
-                "유저1",
-                null,
-                UserRoleType.USER
-        );
     }
 
 }

--- a/src/test/java/com/back/service/ArticleServiceTest.java
+++ b/src/test/java/com/back/service/ArticleServiceTest.java
@@ -1,0 +1,77 @@
+package com.back.service;
+
+import com.back.domain.Article;
+import com.back.domain.ArticleHashtag;
+import com.back.domain.Hashtag;
+import com.back.domain.UserAccount;
+import com.back.repository.ArticleHashtagRepository;
+import com.back.repository.ArticleRepository;
+import com.back.service.dto.ArticleDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static com.back.domain.ArticleMockDataFactoryTest.createDBArticleFromUserAccount;
+import static com.back.domain.HashtagMockDataFactory.createDBHashtagFromIdAndHashtagName;
+import static com.back.domain.UserAccountMockDataFactory.createDBUserAccountFromUserId;
+import static com.back.service.dto.ArticleDtoFactory.createArticleDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @InjectMocks
+    private ArticleService sut;
+
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private ArticleHashtagRepository articleHashtagRepository;
+    @Mock
+    private HashtagService hashtagService;
+    @Mock
+    private UserAccountService userAccountService;
+
+    @DisplayName(
+            "게시글 정보를 입력하면, 본문에서 해시태그 정보를 추출한 뒤 DB에 반영하고, " +
+                    "새로운 해시태그를 저장하며 게시글과 연관 정보를 생성한다."
+    )
+    @Test
+    void givenArticleInfo_whenNewArticle_thenExtractsAndSavesHashtagsAndSavesArticleHashtag() {
+        // Given
+        ArticleDto articleDto = createArticleDto();
+        UserAccount userAccount = createDBUserAccountFromUserId(articleDto.userId());
+        Set<Hashtag> hashtags = Set.of(
+                createDBHashtagFromIdAndHashtagName(1L, "HASHTAG1"),
+                createDBHashtagFromIdAndHashtagName(2L, "HASHTAG2")
+        );
+        Article savedArticle = createDBArticleFromUserAccount(userAccount);
+
+        given(userAccountService.getUserAccount(articleDto.userId())).willReturn(userAccount);
+        given(articleRepository.save(any(Article.class))).willReturn(savedArticle);
+        given(hashtagService.extractAndSaveHashtags(articleDto.content())).willReturn(hashtags);
+        given(articleHashtagRepository.save(any(ArticleHashtag.class)))
+                .willAnswer(invocation -> invocation.getArgument(0)); // 파라미터가 그대로 반환
+
+        // When
+        ArticleDto result = sut.newArticle(articleDto);
+
+        // Then
+        assertThat(result.id()).isEqualTo(savedArticle.getId());
+        then(userAccountService).should().getUserAccount(articleDto.userId());
+        then(articleRepository).should().save(any(Article.class));
+        then(hashtagService).should().extractAndSaveHashtags(articleDto.content());
+        then(articleHashtagRepository).should(times(hashtags.size())).save(any(ArticleHashtag.class));
+    }
+
+}

--- a/src/test/java/com/back/service/HashtagExtractorTest.java
+++ b/src/test/java/com/back/service/HashtagExtractorTest.java
@@ -1,0 +1,42 @@
+package com.back.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("비즈니스 로직 - 해시태그 추출")
+class HashtagExtractorTest {
+
+    private final HashtagExtractor sut = new HashtagExtractor();
+
+    @DisplayName("해시태그가 포함된 content를 전달하면, 해시태그명을 추출하여 Set 형식으로 반환한다.")
+    @Test
+    void givenContentWithHashtags_whenExtractHashtagNamesFromContent_thenReturnsHashtagNameSet() {
+        // Given
+        String content = "게시글 본문입니다. #JAVA, #JPA";
+
+        // When
+        Set<String> result = sut.extractHashtagNamesFromContent(content);
+
+        // Then
+        Set<String> expectedHashTagNames = Set.of("JAVA", "JPA");
+        assertThat(result).isNotNull().containsExactlyElementsOf(expectedHashTagNames);
+    }
+
+    @DisplayName("해시태그가 포함되지 않은 content를 전달하면, 빈 Set을 반환한다.")
+    @Test
+    void givenContentWithoutHashtags_whenExtractHashtagNamesFromContent_thenReturnsEmptySet() {
+        // Given
+        String content = "게시글 본문입니다.";
+
+        // When
+        Set<String> result = sut.extractHashtagNamesFromContent(content);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/src/test/java/com/back/service/HashtagServiceTest.java
+++ b/src/test/java/com/back/service/HashtagServiceTest.java
@@ -1,0 +1,101 @@
+package com.back.service;
+
+import com.back.domain.Hashtag;
+import com.back.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.back.domain.HashtagMockDataFactory.createDBHashtagFromIdAndHashtagName;
+import static com.back.domain.HashtagMockDataFactory.createHashtagFromHashtagName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks
+    private HashtagService sut;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+    @Mock
+    private HashtagExtractor hashtagExtractor;
+
+    @DisplayName("해시태그가 포함되지 않은 content를 전달하면, 빈 Set 반환한다.")
+    @Test
+    void givenContentWithoutHashtags_whenExtractAndSaveHashtags_thenReturnsEmptySet() {
+        // Given
+        String content = "";
+        given(hashtagExtractor.extractHashtagNamesFromContent(content)).willReturn(Set.of());
+
+        // When
+        Set<Hashtag> result = sut.extractAndSaveHashtags(content);
+
+        // Then
+        assertThat(result).isEmpty();
+        then(hashtagExtractor).should().extractHashtagNamesFromContent(content);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("DB에 이미 모든 해시태그가 존재하면, DB에서 가져온 해시태그만 반환한다.")
+    @Test
+    void givenAllHashtagsExistInDB_whenExtractAndSaveHashtags_thenReturnsExistingHashtags() {
+        // Given
+        String content = "본문입니다. #EXIT_HATHTAG1 #EXIT_HASHTAG2";
+        Set<String> hashtagNamesInContent = Set.of("EXIT_HATHTAG1", "EXIT_HASHTAG2");
+        Set<Hashtag> existingHashtags = new HashSet<>(
+                Set.of(
+                        createDBHashtagFromIdAndHashtagName(1L, "EXIT_HATHTAG1"),
+                        createDBHashtagFromIdAndHashtagName(2L, "EXIT_HASHTAG2")
+                )
+        );
+
+        given(hashtagExtractor.extractHashtagNamesFromContent(content)).willReturn(hashtagNamesInContent);
+        given(hashtagRepository.findByHashtagNameIn(hashtagNamesInContent)).willReturn(existingHashtags);
+
+        // When
+        Set<Hashtag> result = sut.extractAndSaveHashtags(content);
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(existingHashtags);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNamesInContent);
+        then(hashtagRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("새로운 해시태그가 있으면 저장 후 기존 + 새로운 해시태그 반환한다.")
+    @Test
+    void givenNewHashtags_whenExtractAndSaveHashtags_thenSavesAndReturnsAllHashtags() {
+        // Given
+        String content = "본문입니다. #NEW_HASHTAG #EXIT_HASHTAG";
+        Set<String> hashtagNamesInContent = Set.of("NEW_HASHTAG", "EXIT_HASHTAG");
+        Set<Hashtag> existingHashtags = new HashSet<>(
+                Set.of(createDBHashtagFromIdAndHashtagName(1L, "EXIT_HASHTAG"))
+        );
+        List<Hashtag> newHashtags = List.of(createHashtagFromHashtagName("NEW_HASHTAG"));
+        given(hashtagExtractor.extractHashtagNamesFromContent(content)).willReturn(hashtagNamesInContent);
+        given(hashtagRepository.findByHashtagNameIn(hashtagNamesInContent)).willReturn(existingHashtags);
+        given(hashtagRepository.saveAll(anySet())).willReturn(newHashtags);
+
+        // When
+        Set<Hashtag> result = sut.extractAndSaveHashtags(content);
+
+        // Then
+        assertThat(result).hasSize(hashtagNamesInContent.size());
+        then(hashtagExtractor).should().extractHashtagNamesFromContent(content);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNamesInContent);
+        then(hashtagRepository).should().saveAll(anySet());
+    }
+
+
+}

--- a/src/test/java/com/back/service/UserAccountServiceTest.java
+++ b/src/test/java/com/back/service/UserAccountServiceTest.java
@@ -1,0 +1,64 @@
+package com.back.service;
+
+import com.back.domain.UserAccount;
+import com.back.exception.UserNotFoundException;
+import com.back.repository.UserAccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.back.domain.UserAccountMockDataFactory.createDBUserAccountFromUserId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 회원")
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceTest {
+
+    @InjectMocks
+    private UserAccountService sut;
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+
+    @DisplayName("존재하는 유저 id를 전달하면, UserAccount 엔티티를 반환한다.")
+    @Test
+    void givenExitingUserId_whenGetUserAccount_thenReturnsUserAccount() {
+        // Given
+        String userId = "user1";
+        UserAccount userAccount = createDBUserAccountFromUserId(userId);
+        given(userAccountRepository.findById(userId)).willReturn(Optional.of(userAccount));
+
+        // When
+        UserAccount result = sut.getUserAccount(userId);
+
+        // Then
+        assertThat(result.getUserId()).isEqualTo(userAccount.getUserId());
+        then(userAccountRepository).should().findById(userId);
+    }
+
+    @DisplayName("존재하지 않는 유저 id를 전달하면, UserNotFoundException 예외를 던진다.")
+    @Test
+    void givenNonExitingUserId_whenGetUserAccount_thenThrowsUserNotFoundException() {
+        // Given
+        String nonExistentUserId = "user2";
+        given(userAccountRepository.findById(nonExistentUserId)).willReturn(Optional.empty());
+
+        // When
+        UserNotFoundException result = assertThrows(UserNotFoundException.class,
+                () -> sut.getUserAccount(nonExistentUserId)
+        );
+
+        // Then
+        assertThat(result).isInstanceOf(UserNotFoundException.class);
+        then(userAccountRepository).should().findById(nonExistentUserId);
+    }
+
+}

--- a/src/test/java/com/back/service/dto/ArticleDtoFactory.java
+++ b/src/test/java/com/back/service/dto/ArticleDtoFactory.java
@@ -1,0 +1,25 @@
+package com.back.service.dto;
+
+public class ArticleDtoFactory {
+
+    private static final String DEFAULT_TITLE = "제목";
+    private static final String DEFAULT_CONTENT = "내용입니다.";
+    private static final String DEFAULT_USER_ID = "user1";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link ArticleDto} 객체를 생성합니다.
+     * <ul>
+     *   <li>title: {@link ArticleDtoFactory#DEFAULT_TITLE}</li>
+     *   <li>content: {@link ArticleDtoFactory#DEFAULT_CONTENT}</li>
+     *   <li>userId: {@link ArticleDtoFactory#DEFAULT_USER_ID}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link ArticleDto} 객체
+     */
+    public static ArticleDto createArticleDto() {
+        return ArticleDto.of(DEFAULT_TITLE, DEFAULT_CONTENT, DEFAULT_USER_ID);
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #11 

## 📝작업 내용
> * 게시글 생성 기능
>   * 게시글 생성 API  `POST /api/v1/articles` 구현
>   * 게시글 본문에서  해시태그를 추출하여 DB에 없으면 DB에 Insert
>   * 게시글 - 해시태그 연결 테이블 save
> * 테스트 코드 추가
>    * 게시글 생성 기능과 관련된 비즈니스 로직, 컨트롤러 테스트 코드 추가
>    * 컨트롤러 테스트에서 시큐리티 비활성화
> * Mock 데이터 추가
>   * `Article`, `Hashtag`, `ArticleHastag` Mock 데이터 추가
> * 일부 엔티티 수정
>   * N:1 관계의 로딩 전략을 지연 로딩으로 수정
>   * 외부에서 엔티티 클래스의 인스턴스 생성을 위한 팩토리 메서드 추가 

## ⛔️ 종료할 이슈 
> This close #11  
