### PR TITLE
[Featrue] 게시글 상세조회 기능

### DIFF
--- a/src/main/java/com/back/controler/ArticleController.java
+++ b/src/main/java/com/back/controler/ArticleController.java
@@ -1,6 +1,7 @@
 package com.back.controler;
 
 import com.back.controler.dto.reponse.ApiResponse;
+import com.back.controler.dto.reponse.ArticleDetailsResponse;
 import com.back.controler.dto.reponse.ArticleWithHashtagsResponse;
 import com.back.controler.dto.reponse.SearchArticleResponse;
 import com.back.controler.dto.request.NewArticleRequest;
@@ -48,6 +49,15 @@ public class ArticleController {
                 ApiResponse.okWithData(
                         articleService.searchArticles(pageable, searchValue, searchType)
                                 .map(SearchArticleResponse::from)
+                )
+        );
+    }
+
+    @GetMapping("/{articleId}")
+    public ResponseEntity<ApiResponse<ArticleDetailsResponse>> getArticleDetails(@PathVariable Long articleId) {
+        return ResponseEntity.ok().body(
+                ApiResponse.okWithData(
+                        ArticleDetailsResponse.from(articleService.getArticleDetails(articleId))
                 )
         );
     }

--- a/src/main/java/com/back/controler/dto/reponse/ArticleDetailsResponse.java
+++ b/src/main/java/com/back/controler/dto/reponse/ArticleDetailsResponse.java
@@ -1,0 +1,65 @@
+package com.back.controler.dto.reponse;
+
+import com.back.service.dto.ArticleWithCommentsWithHashtagsDto;
+import com.back.service.dto.HashtagDto;
+import org.hibernate.validator.constraints.br.CPF;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ArticleDetailsResponse(
+        Long id, // id
+        String title, // 제목
+        String content, // 내용
+        String userId, // 작성자
+        LocalDateTime createdAt, // 작성일
+        String createdBy, // 작성자
+        LocalDateTime modifiedAt, // 수정일
+        String modifiedBy, // 수정자
+        Set<String> hashtagNames, // 해시태그
+        Set<CommentResponse> comments // 댓글
+) {
+
+    public record CommentResponse(
+            Long id,
+            String userId, // 작성자
+            String content, // 댓글 내용
+            LocalDateTime createdAt, // 작성일시
+            String createdBy, // 작성자
+            LocalDateTime modifiedAt, // 수정일시
+            String modifiedBy // 수정자
+    ) {
+
+    }
+
+    public static ArticleDetailsResponse from(ArticleWithCommentsWithHashtagsDto dto) {
+        return new ArticleDetailsResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.userAccountDto().userId(),
+                dto.createdAt(),
+                dto.createdBy(),
+                dto.modifiedAt(),
+                dto.modifiedBy(),
+                dto.hashtagDtos().stream()
+                        .map(HashtagDto::hashtagName)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                dto.commentDtos().stream()
+                        .map(commentDto ->
+                                new CommentResponse(
+                                        commentDto.id(),
+                                        commentDto.userAccountDto().userId(),
+                                        commentDto.content(),
+                                        commentDto.createdAt(),
+                                        commentDto.createdBy(),
+                                        commentDto.modifiedAt(),
+                                        commentDto.modifiedBy()
+                                ))
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/src/main/java/com/back/controler/dto/reponse/ArticleWithHashtagsResponse.java
+++ b/src/main/java/com/back/controler/dto/reponse/ArticleWithHashtagsResponse.java
@@ -4,6 +4,7 @@ import com.back.service.dto.ArticleWithHashtagsDto;
 import com.back.service.dto.HashtagDto;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -26,7 +27,7 @@ public record ArticleWithHashtagsResponse(
                 articleWithHashtagsDto.userAccountDto().userId(),
                 articleWithHashtagsDto.hashtagDtos().stream()
                         .map(HashtagDto::hashtagName)
-                        .collect(Collectors.toSet()),
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 articleWithHashtagsDto.createdAt(),
                 articleWithHashtagsDto.createdBy(),
                 articleWithHashtagsDto.modifiedAt(),

--- a/src/main/java/com/back/controler/dto/reponse/SearchArticleResponse.java
+++ b/src/main/java/com/back/controler/dto/reponse/SearchArticleResponse.java
@@ -6,6 +6,7 @@ import com.back.service.dto.HashtagDto;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,10 +31,10 @@ public record SearchArticleResponse(
                 articleWithHashtagsDto.userAccountDto().userId(),
                 articleWithHashtagsDto.hashtagDtos().stream()
                         .map(HashtagDto::hashtagName)
-                        .collect(Collectors.toSet()),
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 Arrays.stream(SearchType.values())
                         .map(SearchType::getTypeName)
-                        .collect(Collectors.toSet()),
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 articleWithHashtagsDto.createdAt(),
                 articleWithHashtagsDto.createdBy(),
                 articleWithHashtagsDto.modifiedAt(),

--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -29,6 +29,10 @@ public class Article extends BaseEntity {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ArticleHashtag> articleHashtags = new ArrayList<>();
 
+    @ToString.Exclude
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     private Article(UserAccount userAccount, String title, String content) {
         this.userAccount = userAccount;
         this.title = title;

--- a/src/main/java/com/back/domain/Comment.java
+++ b/src/main/java/com/back/domain/Comment.java
@@ -22,7 +22,6 @@ public class Comment extends BaseEntity {
     @ManyToOne(optional = false)
     private UserAccount userAccount; // 작성자
 
-    @Column private Long parentCommentId; // 부모 댓글 id
     @Column(nullable = false, length = 500) private String content; // 본문
 
 }

--- a/src/main/java/com/back/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/back/exception/ArticleNotFoundException.java
@@ -1,0 +1,7 @@
+package com.back.exception;
+
+public class ArticleNotFoundException extends ApplicationException{
+    public ArticleNotFoundException() {
+        super(ErrorCode.ARTICLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/back/exception/ErrorCode.java
+++ b/src/main/java/com/back/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     UNEXPECTED_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "잘못된 검색 타입입니다. 가능한 검색 타입: " +
             Arrays.stream(SearchType.values()).map(SearchType::getTypeName).toList()
     ),
+    ARTICLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "게시글을 찾을 수 없습니다."),
 
     // UserAccount
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/back/service/ArticleService.java
+++ b/src/main/java/com/back/service/ArticleService.java
@@ -4,9 +4,11 @@ import com.back.domain.Article;
 import com.back.domain.Hashtag;
 import com.back.domain.UserAccount;
 import com.back.domain.constant.SearchType;
+import com.back.exception.ArticleNotFoundException;
 import com.back.exception.UnexpectedSearchTypeException;
 import com.back.repository.ArticleRepository;
 import com.back.service.dto.ArticleDto;
+import com.back.service.dto.ArticleWithCommentsWithHashtagsDto;
 import com.back.service.dto.ArticleWithHashtagsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,6 +63,13 @@ public class ArticleService {
                             Arrays.stream(searchValue.split(" ")).toList(), pageable)
                     .map(ArticleWithHashtagsDto::from);
         };
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleWithCommentsWithHashtagsDto getArticleDetails(Long articleId) {
+        return articleRepository.findById(articleId)
+                .map(ArticleWithCommentsWithHashtagsDto::from)
+                .orElseThrow(ArticleNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/back/service/HashtagService.java
+++ b/src/main/java/com/back/service/HashtagService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,13 +33,13 @@ public class HashtagService {
         // DB에 저장해야 할 해시태그
         Set<String> exitingHashtagNames = existingHashtags.stream()
                 .map(Hashtag::getHashtagName)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // DB에 없는 새로운 해시태그
         Set<Hashtag> newHashtags = hashtagNamesInContent.stream()
                 .filter(hashtagName -> !exitingHashtagNames.contains(hashtagName))
                 .map(Hashtag::newHashtag)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         if (!newHashtags.isEmpty()) {
             hashtagRepository.saveAll(newHashtags); // 새로운 해시태그 저장

--- a/src/main/java/com/back/service/dto/ArticleWithCommentsWithHashtagsDto.java
+++ b/src/main/java/com/back/service/dto/ArticleWithCommentsWithHashtagsDto.java
@@ -1,0 +1,44 @@
+package com.back.service.dto;
+
+import com.back.domain.Article;
+import com.back.domain.ArticleHashtag;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ArticleWithCommentsWithHashtagsDto(
+        Long id, // id
+        Set<CommentDto> commentDtos, // 댓글
+        Set<HashtagDto> hashtagDtos, // 해시태그
+        UserAccountDto userAccountDto, // 작성자
+        String title, // 제목
+        String content, // 내용
+        LocalDateTime createdAt, // 작성일시
+        String createdBy, // 작성자
+        LocalDateTime modifiedAt, // 수정일시
+        String modifiedBy // 수정자
+) {
+
+    public static ArticleWithCommentsWithHashtagsDto from(Article entity) {
+        return new ArticleWithCommentsWithHashtagsDto(
+                entity.getId(),
+                entity.getComments().stream()
+                        .map(CommentDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                entity.getArticleHashtags().stream()
+                        .map(ArticleHashtag::getHashtag)
+                        .map(HashtagDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                UserAccountDto.from(entity.getUserAccount()),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+}

--- a/src/main/java/com/back/service/dto/ArticleWithHashtagsDto.java
+++ b/src/main/java/com/back/service/dto/ArticleWithHashtagsDto.java
@@ -4,6 +4,7 @@ import com.back.domain.Article;
 import com.back.domain.ArticleHashtag;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,7 +31,7 @@ public record ArticleWithHashtagsDto(
                         .stream()
                         .map(ArticleHashtag::getHashtag)
                         .map(HashtagDto::from)
-                        .collect(Collectors.toSet()),
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 article.getCreatedAt(),
                 article.getCreatedBy(),
                 article.getModifiedAt(),

--- a/src/main/java/com/back/service/dto/CommentDto.java
+++ b/src/main/java/com/back/service/dto/CommentDto.java
@@ -1,0 +1,29 @@
+package com.back.service.dto;
+
+import com.back.domain.Comment;
+
+import java.time.LocalDateTime;
+
+public record CommentDto(
+        Long id, // id
+        Long articleId, // 게시글 id
+        UserAccountDto userAccountDto, // 작성자
+        String content, // 댓글 내용
+        LocalDateTime createdAt, // 작성일시
+        String createdBy, // 작성자
+        LocalDateTime modifiedAt, // 수정일시
+        String modifiedBy // 수정자
+) {
+    public static CommentDto from(Comment entity) {
+        return new CommentDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                UserAccountDto.from(entity.getUserAccount()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -79,7 +79,7 @@ values ('jpa', '2007-03-13', 'admin1', '2011-05-21', 'admin1');
 insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
 values ('spring', '2013-06-22', 'admin1', '2020-08-04', 'admin1');
 
--- article_hashtag
+--- article_hashtag
 insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
 values (1, 1, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
 insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
@@ -88,3 +88,25 @@ insert into article_hashtag (article_id, hashtag_id, created_at, created_by, mod
 values (2, 2, '2007-03-13', 'admin1', '2011-05-21', 'admin1');
 insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
 values (3, 3, '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+
+--- comment
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'user1', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'admin1', '야구 시즌 시작야구', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (2, 'player789', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'player789', '2015-03-19', 'player789');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'user1', '우승 예상팀우승 예상팀123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'user1', '우승 예상팀우승 예상팀qwd', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 23', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'account4526', '야구 시23', '2002-03-31', 'account4526', '2015-03-19', 'account4526');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'user1', '즌 123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 시작1', '2002-03-31', 'user1', '2015-03-19', 'user1');

--- a/src/test/java/com/back/controler/ArticleControllerTest.java
+++ b/src/test/java/com/back/controler/ArticleControllerTest.java
@@ -149,7 +149,7 @@ class ArticleControllerTest {
 
     @DisplayName("게시글 검색 - 실패")
     @Test
-    void given_whenNewArticle_thenReturns4xx() throws Exception {
+    void givenNonExitingSearchType_whenNewArticle_thenReturns4xx() throws Exception {
         // Given
         String searchValue = "test1";
         String searchTypeStr = "잘못된 타입";

--- a/src/test/java/com/back/domain/ArticleMockDataFactoryTest.java
+++ b/src/test/java/com/back/domain/ArticleMockDataFactoryTest.java
@@ -2,8 +2,12 @@ package com.back.domain;
 
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static com.back.domain.UserAccountMockDataFactory.createDBUserAccount;
+
+
 public class ArticleMockDataFactoryTest {
 
+    private static final Long DEFAULT_ID = 1L;
     private static final String DEFAULT_TITLE = "제목1";
     private static final String DEFAULT_CONTENT = "내용입니다.";
 
@@ -12,7 +16,7 @@ public class ArticleMockDataFactoryTest {
      * <p>
      * 기본값으로 구성된 {@link Article} 객체를 생성합니다.
      * <ul>
-     *   <li>id: {@code 1L}</li>
+     *   <li>id: {@link ArticleMockDataFactoryTest#DEFAULT_ID}</li>
      *   <li>title: {@link ArticleMockDataFactoryTest#DEFAULT_TITLE}</li>
      *   <li>content: {@link ArticleMockDataFactoryTest#DEFAULT_CONTENT}</li>
      *   <li>UserAccount: {@param userAccount}</li>
@@ -23,7 +27,26 @@ public class ArticleMockDataFactoryTest {
      */
     public static Article createDBArticleFromUserAccount(UserAccount userAccount) {
         Article article = Article.newArticle(userAccount, DEFAULT_TITLE, DEFAULT_CONTENT);
-        ReflectionTestUtils.setField(article, "id", 1L);
+        ReflectionTestUtils.setField(article, "id", DEFAULT_ID;
+        return article;
+    }
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link Article} 객체를 생성합니다.
+     * <ul>
+     *   <li>id: {@param articleId}</li>
+     *   <li>title: {@link ArticleMockDataFactoryTest#DEFAULT_TITLE}</li>
+     *   <li>content: {@link ArticleMockDataFactoryTest#DEFAULT_CONTENT}</li>
+     *   <li>UserAccount: {@link UserAccountMockDataFactory#createDBUserAccount()}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link Article} 객체
+     */
+    public static Article createDBArticleFromArticleId(Long articleId) {
+        Article article = Article.newArticle(createDBUserAccount(), DEFAULT_TITLE, DEFAULT_CONTENT);
+        ReflectionTestUtils.setField(article, "id", articleId);
         return article;
     }
 

--- a/src/test/java/com/back/service/ArticleServiceTest.java
+++ b/src/test/java/com/back/service/ArticleServiceTest.java
@@ -77,7 +77,7 @@ class ArticleServiceTest {
         then(hashtagService).should().extractAndSaveHashtags(articleDto.content());
     }
 
-    @DisplayName("검색어와 검새타입 없이 게시글을 검색하면, 페이징 된 게시글 정보를 반환한다.")
+    @DisplayName("검색어와 검색타입 없이 게시글을 검색하면, 페이징 된 게시글 정보를 반환한다.")
     @Test
     void givenNoSearchValueAndType_whenSearchArticles_thenReturnsArticlePage() {
         // Given

--- a/src/test/java/com/back/service/dto/ArticleWithCommentsWithHashtagsDtoFactory.java
+++ b/src/test/java/com/back/service/dto/ArticleWithCommentsWithHashtagsDtoFactory.java
@@ -1,0 +1,45 @@
+package com.back.service.dto;
+
+import java.util.Set;
+
+import static com.back.service.dto.CommentDtoFactory.createCommentDto;
+import static com.back.service.dto.HashtagDtoFactory.createHashtagDto;
+import static com.back.service.dto.UserAccountDtoFactory.createUserAccountDto;
+
+public class ArticleWithCommentsWithHashtagsDtoFactory {
+
+    private static final Long DEFAULT_ID = 1L;
+    private static final String DEFAULT_TITLE = "제목";
+    private static final String DEFAULT_CONTENT = "내용입니다.";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link ArticleWithCommentsWithHashtagsDto} 객체를 생성합니다.
+     * <ul>
+     *   <li>id: {@link ArticleWithCommentsWithHashtagsDtoFactory#DEFAULT_ID}</li>
+     *   <li>commentDtos: {@link CommentDtoFactory#createCommentDto()}</li>
+     *   <li>hashtagDtos: {@link HashtagDtoFactory#createHashtagDto()}</li>
+     *   <li>userAccountDto: {@link UserAccountDtoFactory#createUserAccountDto()}</li>
+     *   <li>title: {@link ArticleWithCommentsWithHashtagsDtoFactory#DEFAULT_TITLE}</li>
+     *   <li>content: {@link ArticleWithCommentsWithHashtagsDtoFactory#DEFAULT_CONTENT}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link ArticleWithCommentsWithHashtagsDto} 객체
+     */
+    public static ArticleWithCommentsWithHashtagsDto createArticleWithCommentsWithHashtagsDto() {
+        return new ArticleWithCommentsWithHashtagsDto(
+                DEFAULT_ID,
+                Set.of(createCommentDto()),
+                Set.of(createHashtagDto()),
+                createUserAccountDto(),
+                DEFAULT_TITLE,
+                DEFAULT_CONTENT,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+}

--- a/src/test/java/com/back/service/dto/CommentDtoFactory.java
+++ b/src/test/java/com/back/service/dto/CommentDtoFactory.java
@@ -1,0 +1,37 @@
+package com.back.service.dto;
+
+import static com.back.service.dto.UserAccountDtoFactory.createUserAccountDto;
+
+public class CommentDtoFactory {
+
+    private static final Long DEFAULT_ID = 1L;
+    private static final Long ARTICLE_ID = 1L;
+    private static final String DEFAULT_CONTENT = "댓글입니다.";
+
+    /**
+     * <p>
+     * 기본값으로 구성된 {@link CommentDto} 객체를 생성합니다.
+     * <ul>
+     *   <li>id: {@link CommentDtoFactory#DEFAULT_ID}</li>
+     *   <li>articleId: {@link CommentDtoFactory#ARTICLE_ID}</li>
+     *   <li>userAccountDto: {@link UserAccountDtoFactory#createUserAccountDto()}</li>
+     *   <li>content: {@link CommentDtoFactory#DEFAULT_CONTENT}</li>
+     * </ul>
+     * </p>
+     *
+     * @return 기본값으로 구성된 {@link CommentDto} 객체
+     */
+    public static CommentDto createCommentDto() {
+        return new CommentDto(
+                DEFAULT_ID,
+                ARTICLE_ID,
+                createUserAccountDto(),
+                DEFAULT_CONTENT,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #9 

## 📝작업 내용
> * `Article`, `Comment` 엔티티를 양방향 관계로 설정 
> * 1차 댓글만 구현하기 때문에 `Comment` 엔티티의 `parentId` 필드 제거
> * 게시글 상세 조회 기능 구현
>     * 게시글 상세 조회  API 구현
>  * `Comment` Mock 데이터 추가
>  * 테스트 코드 추가
>     * 게시글 상세조회 기능과 관련된 비즈니스 로직, 컨트롤러 테스트 코드 추가

## ⛔️ 종료할 이슈 
> This close #9 
