### PR TITLE
[Feature] 간편 로그인 기능 (Kakao API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // oauth2.0 client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // JPA + QueryDSL
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/com/back/config/SecurityConfig.java
+++ b/src/main/java/com/back/config/SecurityConfig.java
@@ -1,10 +1,10 @@
 package com.back.config;
 
 import com.back.domain.UserRoleType;
+import com.back.secuirty.general.handler.*;
 import com.back.secuirty.oauth2.handler.OAuth2AuthFailureHandler;
 import com.back.secuirty.oauth2.handler.Oauth2AuthSuccessHandler;
-import com.back.secuirty.ApiAuthenticationFilter;
-import com.back.secuirty.handler.*;
+import com.back.secuirty.general.ApiAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/back/config/SecurityConfig.java
+++ b/src/main/java/com/back/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.back.config;
 
 import com.back.domain.UserRoleType;
+import com.back.secuirty.oauth2.handler.OAuth2AuthFailureHandler;
+import com.back.secuirty.oauth2.handler.Oauth2AuthSuccessHandler;
 import com.back.secuirty.ApiAuthenticationFilter;
 import com.back.secuirty.handler.*;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.context.DelegatingSecurityContextRepository;
@@ -34,6 +39,10 @@ public class SecurityConfig {
     private final ApiAccessDeniedHandler deniedHandler;
     private final ApiLoginAuthenticationEntryPoint entryPoint;
     private final ApiLogoutSuccessHandler logoutSuccessHandler;
+    private final Oauth2AuthSuccessHandler oauth2AuthSuccessHandler;
+    private final OAuth2AuthFailureHandler oauth2AuthFailureHandler;
+
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -58,6 +67,13 @@ public class SecurityConfig {
                         .clearAuthentication(true) // 인증 정보 삭제
                         .deleteCookies("JSESSIONID")
 
+                )
+                .oauth2Login(oAuth -> oAuth.
+                        userInfoEndpoint(useInfo -> useInfo
+                                .userService(oAuth2UserService)
+                        )
+                        .successHandler(oauth2AuthSuccessHandler)
+                        .failureHandler(oauth2AuthFailureHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/back/domain/UserAccount.java
+++ b/src/main/java/com/back/domain/UserAccount.java
@@ -19,8 +19,8 @@ public class UserAccount extends BaseEntity {
     private String userId; // 유저 id
 
     @Column(nullable = false) private String userPassword; // 패스워드
-    @Column(unique = true, length = 50) private String email; // 이메일
-    @Column(unique = true, length = 50) private String nickname; // 닉네임
+    @Column(length = 50) private String email; // 이메일
+    @Column(length = 50) private String nickname; // 닉네임
     @Column private String memo; // 메모
     @Column private String socialProvider; // 소셜 로그인 제공처
     @Column private String socialId; // 유저 소셜 고유 id

--- a/src/main/java/com/back/domain/UserAccount.java
+++ b/src/main/java/com/back/domain/UserAccount.java
@@ -38,8 +38,40 @@ public class UserAccount extends BaseEntity {
         this.role = role;
     }
 
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo,
+                        String socialProvider, String socialId, UserRoleType role, String createdBy, String modifiedBy) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+        this.socialProvider = socialProvider;
+        this.socialId = socialId;
+        this.role = role;
+        this.createdBy = createdBy;
+        this.modifiedBy = modifiedBy;
+    }
+
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo, UserRoleType role) {
         return new UserAccount(userId, userPassword, email, nickname, memo, role);
+    }
+
+    public static UserAccount createOAuth2UserAccount(
+            String userId, String userPassword, String email, String nickname, String memo,
+            String socialProvider, String socialId, UserRoleType role
+    ) {
+        return new UserAccount(
+                userId,
+                userPassword,
+                email,
+                nickname,
+                memo,
+                socialProvider,
+                socialId,
+                role,
+                userId,
+                userId
+        );
     }
 
 }

--- a/src/main/java/com/back/secuirty/general/ApiAuthenticationFilter.java
+++ b/src/main/java/com/back/secuirty/general/ApiAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.back.secuirty;
+package com.back.secuirty.general;
 
 import com.back.controler.dto.request.LoginRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/back/secuirty/general/ApiAuthenticationProvider.java
+++ b/src/main/java/com/back/secuirty/general/ApiAuthenticationProvider.java
@@ -1,5 +1,6 @@
-package com.back.secuirty;
+package com.back.secuirty.general;
 
+import com.back.secuirty.BoardUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;

--- a/src/main/java/com/back/secuirty/general/ApiAuthenticationToken.java
+++ b/src/main/java/com/back/secuirty/general/ApiAuthenticationToken.java
@@ -1,4 +1,4 @@
-package com.back.secuirty;
+package com.back.secuirty.general;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/back/secuirty/general/BoardUserDetailsService.java
+++ b/src/main/java/com/back/secuirty/general/BoardUserDetailsService.java
@@ -1,6 +1,7 @@
-package com.back.secuirty;
+package com.back.secuirty.general;
 
 import com.back.repository.UserAccountRepository;
+import com.back.secuirty.BoardUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/back/secuirty/general/handler/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/back/secuirty/general/handler/ApiAccessDeniedHandler.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.secuirty.general.handler;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import jakarta.servlet.ServletException;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * 인증은 되었지만, 요청한 리소스에 대한 권한이 없을 때 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/general/handler/ApiAuthenticationFailureHandler.java
+++ b/src/main/java/com/back/secuirty/general/handler/ApiAuthenticationFailureHandler.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.secuirty.general.handler;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * 인증 실패 시 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/general/handler/ApiAuthenticationSuccessHandler.java
+++ b/src/main/java/com/back/secuirty/general/handler/ApiAuthenticationSuccessHandler.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.secuirty.general.handler;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * 인증 성공 시 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/general/handler/ApiLoginAuthenticationEntryPoint.java
+++ b/src/main/java/com/back/secuirty/general/handler/ApiLoginAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.secuirty.general.handler;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * 로그인 하지 않은 사용자가 접근했을 때 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/general/handler/ApiLogoutSuccessHandler.java
+++ b/src/main/java/com/back/secuirty/general/handler/ApiLogoutSuccessHandler.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.secuirty.general.handler;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import jakarta.servlet.ServletException;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 @Slf4j
 @Component

--- a/src/main/java/com/back/secuirty/oauth2/KakaoOAuth2UserService.java
+++ b/src/main/java/com/back/secuirty/oauth2/KakaoOAuth2UserService.java
@@ -1,0 +1,59 @@
+package com.back.secuirty.oauth2;
+
+import com.back.domain.UserAccount;
+import com.back.domain.UserRoleType;
+import com.back.exception.UserNotFoundException;
+import com.back.secuirty.BoardUserDetails;
+import com.back.secuirty.oauth2.response.KakaoOAuth2Response;
+import com.back.service.UserAccountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserAccountService userAccountService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+        KakaoOAuth2Response kakaoOAuth2Response = KakaoOAuth2Response.from(oAuth2User.getAttributes());
+
+        // OAuth2 사용자 데이터 생성
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // kakao
+        String nickname = kakaoOAuth2Response.nickname(); // kakao 사용자 닉네임
+        String providerId = String.valueOf(kakaoOAuth2Response.id()); // kakao 사용자 고유 id
+        String userId = registrationId + "_" + providerId; // kakao_{사용자}
+        String password = UUID.randomUUID().toString(); // 패스워드 랜덤값
+
+        try {
+            UserAccount userAccount = userAccountService.getUserAccount(userId);
+            return BoardUserDetails.from(userAccount);
+        } catch (UserNotFoundException e) {
+            return BoardUserDetails.of(
+                    userAccountService.saveUser(
+                            userId,
+                            password,
+                            null,
+                            nickname,
+                            null,
+                            registrationId,
+                            providerId,
+                            UserRoleType.USER
+                    ),
+                    kakaoOAuth2Response.properties()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/back/secuirty/oauth2/handler/OAuth2AuthFailureHandler.java
+++ b/src/main/java/com/back/secuirty/oauth2/handler/OAuth2AuthFailureHandler.java
@@ -1,0 +1,34 @@
+package com.back.secuirty.oauth2.handler;
+
+import com.back.controler.dto.reponse.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+
+/**
+ * 인증 실패 시 호출되는 핸들러
+ */
+@Slf4j
+@Component
+public class OAuth2AuthFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException {
+        log.info("[OAuth2 Auth Failed] : {} : {}", request.getAttribute("username"), exception.getMessage());
+        ApiResponse<Void> apiResponse = ApiResponse.errorWithMessage(HttpStatus.BAD_REQUEST, "OAuth2 로그인 실패.");
+        sendResponseWithBody(response, apiResponse);
+    }
+
+}

--- a/src/main/java/com/back/secuirty/oauth2/handler/OAuth2AuthFailureHandler.java
+++ b/src/main/java/com/back/secuirty/oauth2/handler/OAuth2AuthFailureHandler.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * 인증 실패 시 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/oauth2/handler/Oauth2AuthSuccessHandler.java
+++ b/src/main/java/com/back/secuirty/oauth2/handler/Oauth2AuthSuccessHandler.java
@@ -1,0 +1,37 @@
+package com.back.secuirty.oauth2.handler;
+
+import com.back.controler.dto.reponse.ApiResponse;
+import com.back.secuirty.BoardUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+
+/**
+ * OAuth2 인증 성공 시 호출되는 핸들러
+ */
+@Slf4j
+@Component
+public class Oauth2AuthSuccessHandler implements AuthenticationSuccessHandler {
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        if (authentication.getPrincipal() instanceof BoardUserDetails userDetails) {
+            String username = userDetails.getUsername();
+            log.info("[Authentication Succeed] Username: {}", username);
+        } else {
+            log.warn("[Authentication Succeed] 사용자 정보를 가져올 수 없습니다.");
+        }
+        ApiResponse<Void> apiResponse = ApiResponse.okWithMessage("로그인 성공.");
+        sendResponseWithBody(response, apiResponse);
+    }
+}

--- a/src/main/java/com/back/secuirty/oauth2/handler/Oauth2AuthSuccessHandler.java
+++ b/src/main/java/com/back/secuirty/oauth2/handler/Oauth2AuthSuccessHandler.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.back.secuirty.handler.HandlerUtils.sendResponseWithBody;
+import static com.back.util.ResponseUtils.sendResponseWithBody;
 
 /**
  * OAuth2 인증 성공 시 호출되는 핸들러

--- a/src/main/java/com/back/secuirty/oauth2/response/KakaoOAuth2Response.java
+++ b/src/main/java/com/back/secuirty/oauth2/response/KakaoOAuth2Response.java
@@ -1,0 +1,54 @@
+package com.back.secuirty.oauth2.response;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@SuppressWarnings("unchecked") // Map -> Object 변환 로직이 있어 제네릭 타입 캐스팅 문제를 무시
+public record KakaoOAuth2Response(
+        Long id,
+        LocalDateTime connectedAt,
+        Map<String, Object> properties,
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            Boolean profileNicknameNeedsAgreement,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname,
+                Boolean isDefaultNickname
+        ) {
+        }
+    }
+
+    public static KakaoOAuth2Response from(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccountMap = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profileMap = (Map<String, Object>) kakaoAccountMap.get("profile");
+
+        KakaoAccount.Profile profile = new KakaoAccount.Profile(
+                String.valueOf(profileMap.get("nickname")),
+                Boolean.valueOf(String.valueOf(profileMap.get("is_default_nickname")))
+        );
+        KakaoAccount kakaoAccount = new KakaoAccount(
+                Boolean.valueOf(String.valueOf(kakaoAccountMap.get("profile_nickname_needs_agreement"))),
+                profile
+        );
+
+        return new KakaoOAuth2Response(
+                Long.valueOf(String.valueOf(attributes.get("id"))),
+                LocalDateTime.parse(
+                        String.valueOf(attributes.get("connected_at")),
+                        DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault())
+                ),
+                (Map<String, Object>) attributes.get("properties"),
+                kakaoAccount
+        );
+    }
+
+    public String nickname() {
+        return this.kakaoAccount.profile.nickname;
+    }
+
+}

--- a/src/main/java/com/back/service/UserAccountService.java
+++ b/src/main/java/com/back/service/UserAccountService.java
@@ -1,8 +1,10 @@
 package com.back.service;
 
 import com.back.domain.UserAccount;
+import com.back.domain.UserRoleType;
 import com.back.exception.UserNotFoundException;
 import com.back.repository.UserAccountRepository;
+import com.back.service.dto.UserAccountDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,4 +22,11 @@ public class UserAccountService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    public UserAccountDto saveUser(
+            String userId, String password, String email, String nickname,
+            String memo, String socialProvider, String socialId, UserRoleType role
+    ) {
+        UserAccount userAccount = UserAccount.createOAuth2UserAccount(userId, password, email, nickname, memo, socialProvider, socialId, role);
+        return UserAccountDto.from(userAccountRepository.save(userAccount));
+    }
 }

--- a/src/main/java/com/back/util/ResponseUtils.java
+++ b/src/main/java/com/back/util/ResponseUtils.java
@@ -1,4 +1,4 @@
-package com.back.secuirty.handler;
+package com.back.util;
 
 import com.back.controler.dto.reponse.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-public class HandlerUtils {
+public class ResponseUtils {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,10 @@ debug: false
 logging:
   level:
     com.back: debug
-    org.springframework:
-      web.servlet: debug
-      security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
+    org.springframework.web.servlet: debug
+    org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+    org.springframework.web.client.RestTemplate: DEBUG
 
 server:
   port: 8080
@@ -26,3 +26,19 @@ spring:
         default_batch_fetch_size: 100
   sql.init.mode: always
   h2.console.enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_OAUTH_CLIENT_ID}
+            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/test/java/com/back/config/UnsecuredWebMvcTest.java
+++ b/src/test/java/com/back/config/UnsecuredWebMvcTest.java
@@ -1,0 +1,39 @@
+package com.back.config;
+
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WebMvcTest(
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        },
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfig.class
+                ),
+        }
+)
+public @interface UnsecuredWebMvcTest {
+    @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")
+    Class<?>[] value() default {};
+
+    @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")
+    Class<?>[] controllers() default {};
+}

--- a/src/test/java/com/back/controler/ArticleControllerTest.java
+++ b/src/test/java/com/back/controler/ArticleControllerTest.java
@@ -1,7 +1,7 @@
 package com.back.controler;
 
 import com.back.config.JsonDataEncoder;
-import com.back.config.SecurityConfig;
+import com.back.config.UnsecuredWebMvcTest;
 import com.back.controler.converter.SearchTypeRequestConverter;
 import com.back.controler.dto.request.ArticleUpdateRequest;
 import com.back.controler.dto.request.NewArticleRequest;
@@ -18,10 +18,7 @@ import com.back.service.dto.NewArticleRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -45,16 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("컨트롤러 - 게시글")
 @Import({JsonDataEncoder.class})
-@WebMvcTest(
-        controllers = ArticleController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class,
-        excludeFilters = {
-                @ComponentScan.Filter(
-                        type = FilterType.ASSIGNABLE_TYPE,
-                        classes = SecurityConfig.class
-                ),
-        }
-)
+@UnsecuredWebMvcTest(controllers = ArticleController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class ArticleControllerTest {
 
     @Autowired

--- a/src/test/java/com/back/controler/CommentControllerTest.java
+++ b/src/test/java/com/back/controler/CommentControllerTest.java
@@ -1,7 +1,7 @@
 package com.back.controler;
 
 import com.back.config.JsonDataEncoder;
-import com.back.config.SecurityConfig;
+import com.back.config.UnsecuredWebMvcTest;
 import com.back.controler.dto.request.NewCommentRequest;
 import com.back.exception.ArticleNotFoundException;
 import com.back.exception.CommentNotFoundException;
@@ -11,10 +11,6 @@ import com.back.service.dto.NewCommentRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -31,16 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("컨트롤러 - 댓글")
 @Import({JsonDataEncoder.class})
-@WebMvcTest(
-        controllers = CommentController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class,
-        excludeFilters = {
-                @ComponentScan.Filter(
-                        type = FilterType.ASSIGNABLE_TYPE,
-                        classes = SecurityConfig.class
-                ),
-        }
-)
+@UnsecuredWebMvcTest(controllers = CommentController.class)
 public class CommentControllerTest {
 
     @Autowired

--- a/src/test/java/com/back/secuirty/BoardUserDetailsServiceTest.java
+++ b/src/test/java/com/back/secuirty/BoardUserDetailsServiceTest.java
@@ -2,6 +2,7 @@ package com.back.secuirty;
 
 import com.back.domain.UserAccount;
 import com.back.repository.UserAccountRepository;
+import com.back.secuirty.general.BoardUserDetailsService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #7 

## 📝작업 내용
> * 간편 로그인 기능 구현
>   * `OAuth2 Client`를 사용하여 카카오 간편 로그인 기능을 구현
>   * 디버깅을 위해 로그레벨 설정
>   * 카카오 사용자의 닉네임과 이메일에 접근 권한이 없으므로 `UserAccount` 엔티티에서 `nickname`, `email` 필드의 uq 제약조건을 제거
>   * 카카오 `CLIENT_ID`, `CLIENT_SECRET`를 프로퍼티에 정의하지 않고 외부 환경변수로 주입
>  * 리팩토링
>    *  시큐리티 관련 클래스 패키지 변경
> * 테스트 코드
>   *  시큐리티 관련 설정(인증 필터, OAuth2)을 모두 제외하기 위한 `UnsecuredWebMvcTest` 어노테이션 정의


## ⛔️ 종료할 이슈 
> This close #7  
