### PR TITLE
[Feature]Controller 요청/응답 로그 기록

### DIFF
--- a/src/main/java/com/back/controler/ArticleController.java
+++ b/src/main/java/com/back/controler/ArticleController.java
@@ -9,8 +9,10 @@ import com.back.controler.dto.request.NewArticleRequest;
 import com.back.domain.constant.SearchType;
 import com.back.secuirty.BoardUserDetails;
 import com.back.service.ArticleService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,72 +21,87 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/v1/articles")
 @RestController
-public class ArticleController {
+public class ArticleController extends BaseController {
 
     private final ArticleService articleService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<ArticleWithHashtagsResponse>> newArticle(
             @RequestBody @Valid NewArticleRequest request,
-            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails,
+            HttpServletRequest httpServletRequest
     ) {
-        return ResponseEntity.ok().body(
-                ApiResponse.okWithData(
-                        ArticleWithHashtagsResponse.from(
-                                articleService.newArticle(request.toDto(boardUserDetails.toDto()))
-                        )
+        requestLog(log, httpServletRequest, request);
+        ApiResponse<ArticleWithHashtagsResponse> response = ApiResponse.okWithData(
+                ArticleWithHashtagsResponse.from(
+                        articleService.newArticle(request.toDto(boardUserDetails.toDto()))
                 )
         );
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<SearchArticleResponse>>> getArticles(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) String searchValue,
-            @RequestParam(required = false) SearchType searchType
+            @RequestParam(required = false) SearchType searchType,
+            HttpServletRequest httpServletRequest
     ) {
-        return ResponseEntity.ok().body(
-                ApiResponse.okWithData(
-                        articleService.searchArticles(pageable, searchValue, searchType)
-                                .map(SearchArticleResponse::from)
-                )
+        requestLog(log, httpServletRequest);
+        ApiResponse<Page<SearchArticleResponse>> response = ApiResponse.okWithData(
+                articleService.searchArticles(pageable, searchValue, searchType)
+                        .map(SearchArticleResponse::from)
         );
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/{articleId}")
-    public ResponseEntity<ApiResponse<ArticleDetailsResponse>> getArticleDetails(@PathVariable Long articleId) {
-        return ResponseEntity.ok().body(
-                ApiResponse.okWithData(
-                        ArticleDetailsResponse.from(articleService.getArticleDetails(articleId))
-                )
+    public ResponseEntity<ApiResponse<ArticleDetailsResponse>> getArticleDetails(
+            @PathVariable Long articleId,
+            HttpServletRequest httpServletRequest
+    ) {
+        requestLog(log, httpServletRequest);
+        ApiResponse<ArticleDetailsResponse> response = ApiResponse.okWithData(
+                ArticleDetailsResponse.from(articleService.getArticleDetails(articleId))
         );
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
     @PatchMapping("/{articleId}")
     public ResponseEntity<ApiResponse<ArticleWithHashtagsResponse>> updateArticle(
             @PathVariable Long articleId,
             @RequestBody @Valid ArticleUpdateRequest request,
-            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails,
+            HttpServletRequest httpServletRequest
     ) {
-        return ResponseEntity.ok().body(
-                ApiResponse.okWithData(
-                        ArticleWithHashtagsResponse.from(
-                                articleService.updateArticle(request.toDto(articleId, boardUserDetails.toDto()))
-                        )
+        requestLog(log, httpServletRequest, request);
+        ApiResponse<ArticleWithHashtagsResponse> response = ApiResponse.okWithData(
+                ArticleWithHashtagsResponse.from(
+                        articleService.updateArticle(request.toDto(articleId, boardUserDetails.toDto()))
                 )
         );
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{articleId}")
     public ResponseEntity<ApiResponse<Void>> updateArticle(
             @PathVariable Long articleId,
-            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails,
+            HttpServletRequest httpServletRequest
     ) {
+        requestLog(log, httpServletRequest);
         articleService.deleteArticle(articleId, boardUserDetails.userId());
-        return ResponseEntity.ok().body(ApiResponse.okWithMessage("삭제 성공."));
+        ApiResponse<Void> response = ApiResponse.okWithMessage("삭제 성공.");
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/com/back/controler/BaseController.java
+++ b/src/main/java/com/back/controler/BaseController.java
@@ -1,0 +1,31 @@
+package com.back.controler;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+
+public class BaseController {
+
+    protected void requestLog(Logger logger, HttpServletRequest request) {
+        logger.info("Request {} {} ", request.getMethod(), getFullUri(request));
+    }
+
+    protected <T> void requestLog(Logger logger, HttpServletRequest request, T body) {
+        logger.info("Request {} {}: {}", request.getMethod(), getFullUri(request), body);
+    }
+
+    protected <T> void responseLog(Logger logger, HttpServletRequest request, T body) {
+        logger.info("Response {} {}: {}", request.getMethod(), getFullUri(request), body);
+    }
+
+    protected void responseLog(Logger logger, HttpServletRequest request) {
+        logger.info("Response {} {}", request.getMethod(), getFullUri(request));
+    }
+
+    private String getFullUri(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String query = request.getQueryString();
+        return query != null ? uri + "?" + query : uri;
+    }
+
+}

--- a/src/main/java/com/back/controler/CommentController.java
+++ b/src/main/java/com/back/controler/CommentController.java
@@ -5,39 +5,49 @@ import com.back.controler.dto.reponse.ArticleDetailsResponse;
 import com.back.controler.dto.request.NewCommentRequest;
 import com.back.secuirty.BoardUserDetails;
 import com.back.service.CommentService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/v1/comments")
 @RestController
-public class CommentController {
+public class CommentController extends BaseController {
 
     private final CommentService commentService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<ArticleDetailsResponse>> newComment(
             @RequestBody @Valid NewCommentRequest request,
-            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails,
+            HttpServletRequest httpServletRequest
     ) {
-        return ResponseEntity.ok().body(
-                ApiResponse.okWithData(
-                        ArticleDetailsResponse.from(
-                                commentService.newComment(request.toDto(boardUserDetails.toDto()))
-                        )
+        requestLog(log, httpServletRequest, request);
+        ApiResponse<ArticleDetailsResponse> response = ApiResponse.okWithData(
+                ArticleDetailsResponse.from(
+                        commentService.newComment(request.toDto(boardUserDetails.toDto()))
                 )
         );
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
             @PathVariable Long commentId,
-            @AuthenticationPrincipal BoardUserDetails boardUserDetails
+            @AuthenticationPrincipal BoardUserDetails boardUserDetails,
+            HttpServletRequest httpServletRequest
     ) {
+        requestLog(log, httpServletRequest);
         commentService.deleteComment(commentId, boardUserDetails.userId());
-        return ResponseEntity.ok().body(ApiResponse.okWithMessage("삭제 성공."));
+        ApiResponse<Void> response = ApiResponse.okWithMessage("삭제 성공.");
+        responseLog(log, httpServletRequest, response);
+        return ResponseEntity.ok().body(response);
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
* #37 

## 📝작업 내용
* 모든 컨트롤러는 `BaseController`를 상속받도록 수정하였고,
공통적으로 제공되는 `BaseController#requestLog()` 및 `responseLog()` 메서드를 통해
요청(Request) 및 응답(Response)에 대한 로그를 남기도록 통일했다.
* `Filter` 또는 `HandlerInterceptor`를 통해 모든 요청/응답에 대한 로그를 남기는 방식도 고려하였으나, 요청/응답 본문을 읽기가 번거롭고, 커스터마이징 측면에서 컨트롤러 내부 처리 방식이 더 유연하다고 판단되어 현재 방식으로 적용했다.

## ⛔️ 종료할 이슈 
* This close #37  
