### PR TITLE
[Feature] API 요청 처리 시간 로깅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 .env
+
+**/src/main/**/generated/

--- a/src/main/java/com/back/config/WebConfig.java
+++ b/src/main/java/com/back/config/WebConfig.java
@@ -1,9 +1,11 @@
 package com.back.config;
 
+import com.back.config.interceptor.RequestTimeInterceptor;
 import com.back.controler.converter.SearchTypeRequestConverter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
@@ -13,6 +15,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new SearchTypeRequestConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RequestTimeInterceptor());
     }
 
 }

--- a/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
+++ b/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
@@ -28,10 +28,11 @@ public class RequestTimeInterceptor implements HandlerInterceptor {
 
         String uri = request.getRequestURI();
         String method = request.getMethod();
-        log.info("[{} {}] execute time : {}ms", method, uri, executeTime);
 
         if (executeTime > LONG_TIME_MS) {
             log.warn("[{} {}] Slow Request! execute time : {}ms", method, uri, executeTime);
+        } else {
+            log.info("[{} {}] execute time : {}ms", method, uri, executeTime);
         }
     }
 

--- a/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
+++ b/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
@@ -30,7 +30,7 @@ public class RequestTimeInterceptor implements HandlerInterceptor {
         String method = request.getMethod();
         log.info("[{} {}] execute time : {}ms", method, uri, executeTime);
 
-        if (executeTime < LONG_TIME_MS) {
+        if (executeTime > LONG_TIME_MS) {
             log.warn("[{} {}] Slow Request! execute time : {}ms", method, uri, executeTime);
         }
     }

--- a/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
+++ b/src/main/java/com/back/config/interceptor/RequestTimeInterceptor.java
@@ -1,0 +1,38 @@
+package com.back.config.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+public class RequestTimeInterceptor implements HandlerInterceptor {
+
+    private static final Long LONG_TIME_MS = 3000L;
+    private static final String START_TIME_ATTRIBUTE = "startTime";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        long startTime = System.currentTimeMillis();
+        request.setAttribute(START_TIME_ATTRIBUTE, startTime);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        long startTime = (Long) request.getAttribute(START_TIME_ATTRIBUTE);
+        long endTime = System.currentTimeMillis();
+        long executeTime = endTime - startTime;
+
+        String uri = request.getRequestURI();
+        String method = request.getMethod();
+        log.info("[{} {}] execute time : {}ms", method, uri, executeTime);
+
+        if (executeTime < LONG_TIME_MS) {
+            log.warn("[{} {}] Slow Request! execute time : {}ms", method, uri, executeTime);
+        }
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #40 

## 📝작업 내용
> - 모든 API 처리시간을 로그로 기록하도록 Interceptor 추가 
>   - 3000ms 이상이면 warn 로그를 남기도록 함.
> - 해당 이슈와 연관된 내용은 아니지만, QueryDSL의 QClass의 Git 추적을 금지하기 위해 gitIgnore에 추가

### 스크린샷 (선택)
- 일반적인 상황(처리 시간이 3000ms 이하인 경우)
![image](https://github.com/user-attachments/assets/5d86598e-4081-4b5f-8258-6caae594c322)

- 처리 시간인 3000ms 이상인 경우
![image](https://github.com/user-attachments/assets/aa714239-b371-4636-bb5f-258bb2df7ac7)


## ⛔️ 종료할 이슈 
> This close #40  
