### PR TITLE
[Bug] 해시태그 검색 API page 속성 불일치 문제, Repepository 테스트 코드 추가

### DIFF
--- a/src/main/java/com/back/config/JpaConfig.java
+++ b/src/main/java/com/back/config/JpaConfig.java
@@ -1,6 +1,10 @@
 package com.back.config;
 
 import com.back.secuirty.BoardUserDetails;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -9,11 +13,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.Optional;
-
+@RequiredArgsConstructor
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
+
+    private final EntityManager em;
 
     @Bean
     public AuditorAware<String> auditorAware() {
@@ -23,6 +28,11 @@ public class JpaConfig {
                 .map(Authentication::getPrincipal)
                 .map(BoardUserDetails.class::cast)
                 .map(BoardUserDetails::getUsername);
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
     }
 
 }

--- a/src/main/java/com/back/config/SecurityConfig.java
+++ b/src/main/java/com/back/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.back.secuirty.general.ApiAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,6 +26,7 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
 import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+@Profile("!test")
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {

--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -1,18 +1,28 @@
 package com.back.domain;
 
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -20,6 +30,7 @@ public class Article extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id; // id
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
@@ -78,5 +89,19 @@ public class Article extends BaseEntity {
                 removeHashtags.contains(articleHashtag.getHashtag())
         );
     }
+
+//    @Override
+//    public boolean equals(Object o) {
+//        if (o == null || getClass() != o.getClass()) {
+//            return false;
+//        }
+//        Article article = (Article) o;
+//        return Objects.equals(getId(), article.getId());
+//    }
+//
+//    @Override
+//    public int hashCode() {
+//        return Objects.hashCode(getId());
+//    }
 
 }

--- a/src/main/java/com/back/domain/UserAccount.java
+++ b/src/main/java/com/back/domain/UserAccount.java
@@ -6,9 +6,13 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -16,6 +20,7 @@ public class UserAccount extends BaseEntity {
 
     @Id
     @Column(nullable = false, length = 50)
+    @EqualsAndHashCode.Include
     private String userId; // 유저 id
 
     @Column(nullable = false) private String userPassword; // 패스워드

--- a/src/main/java/com/back/repository/custom/ArticleCustomRepositoryImpl.java
+++ b/src/main/java/com/back/repository/custom/ArticleCustomRepositoryImpl.java
@@ -4,22 +4,19 @@ import com.back.domain.Article;
 import com.back.domain.QArticle;
 import com.back.domain.QArticleHashtag;
 import com.back.domain.QHashtag;
-import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
-import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
-import java.util.List;
 
-@Repository
-public class ArticleCustomRepositoryImpl extends QuerydslRepositorySupport implements ArticleCustomRepository{
+@RequiredArgsConstructor
+public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
-    public ArticleCustomRepositoryImpl() {
-        super(Article.class);
-    }
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Page<Article> findByHashtagNames(Collection<String> hashtagNames, Pageable pageable) {
@@ -27,12 +24,25 @@ public class ArticleCustomRepositoryImpl extends QuerydslRepositorySupport imple
         QHashtag hashtag = QHashtag.hashtag;
         QArticleHashtag articleHashtag = QArticleHashtag.articleHashtag;
 
-        JPQLQuery<Article> query = from(article)
+        List<Article> articles = queryFactory
+                .select(article)
+                .from(article)
                 .innerJoin(article.articleHashtags, articleHashtag)
                 .innerJoin(articleHashtag.hashtag, hashtag)
-                .where(hashtag.hashtagName.in(hashtagNames));
-        List<Article> articles = getQuerydsl().applyPagination(pageable, query).fetch();
-        return new PageImpl<>(articles, pageable, articles.size());
+                .where(hashtag.hashtagName.in(hashtagNames))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(article.countDistinct())
+                .from(article)
+                .innerJoin(article.articleHashtags, articleHashtag)
+                .innerJoin(articleHashtag.hashtag, hashtag)
+                .where(hashtag.hashtagName.in(hashtagNames))
+                .fetchOne();
+
+        return new PageImpl<>(articles, pageable, count == null ? 0 : count);
     }
 
 }

--- a/src/test/java/com/back/MyBoardBackendApplicationTests.java
+++ b/src/test/java/com/back/MyBoardBackendApplicationTests.java
@@ -1,8 +1,14 @@
 package com.back;
 
+import com.back.config.TestSecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
+
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
 @SpringBootTest
 class MyBoardBackendApplicationTests {
 

--- a/src/test/java/com/back/config/TestJpaConfig.java
+++ b/src/test/java/com/back/config/TestJpaConfig.java
@@ -1,0 +1,29 @@
+package com.back.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@TestConfiguration
+public class TestJpaConfig {
+
+    @Autowired
+    private EntityManager em;
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.of("test-user");
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/src/test/java/com/back/config/TestSecurityConfig.java
+++ b/src/test/java/com/back/config/TestSecurityConfig.java
@@ -1,0 +1,28 @@
+package com.back.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+}

--- a/src/test/java/com/back/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/back/repository/ArticleRepositoryTest.java
@@ -1,0 +1,192 @@
+package com.back.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.back.config.TestJpaConfig;
+import com.back.domain.Article;
+import com.back.domain.ArticleMockDataFactory;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("Repository - 게시글")
+@Sql(scripts = "/sql/data.sql")
+@Import(TestJpaConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DataJpaTest
+class ArticleRepositoryTest {
+
+    @Autowired
+    private ArticleRepository sut;
+
+    @DisplayName("게시글 ID를 전달하면, 해당되는 게시글을 조회할 수 있다")
+    @Test
+    void givenArticleId_whenFindById_thenReturnsMatchingArticle() {
+        // Given
+        Long articleId = 1L;
+
+        // When
+        Optional<Article> result = sut.findById(articleId);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(articleId);
+    }
+
+    @DisplayName("존재하지 않는 게시글 ID를 전달하면, 빈 Optional을 반환한다")
+    @Test
+    void givenNotExistArticleId_whenFindById_thenReturnsEmptyOptional() {
+        // Given
+        Long articleId = -1L;
+
+        // When
+        Optional<Article> result = sut.findById(articleId);
+
+        // Then
+        assertThat(result).isNotPresent();
+    }
+
+    @DisplayName("페이징 정보를 전달하면, 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenPageable_whenFindAll_thenReturnsMatchingArticles() {
+        // Given
+        int pageSize = 10;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        // When
+        Page<Article> result = sut.findAll(pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(pageSize);
+    }
+
+    @DisplayName("검색어와 페이징 정보를 전달하면, 제목에 검색어가 포함된 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenSearchValueAndPageable_whenFindByTitleContaining_thenReturnsMatchingArticles() {
+        // Given
+        String searchValue = "우승";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When
+        Page<Article> result = sut.findByTitleContaining(searchValue, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting(Article::getTitle)
+                .allMatch(title -> title.contains(searchValue));
+    }
+
+    @DisplayName("검색어와 페이징 정보를 전달하면, 본문에 검색어가 포함된 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenSearchValueAndPageable_whenFindByContentContaining_thenReturnsMatchingArticles() {
+        // Given
+        String searchValue = "야구";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When
+        Page<Article> result = sut.findByContentContaining(searchValue, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting(Article::getContent)
+                .allMatch(content -> content.contains(searchValue));
+    }
+
+    @DisplayName("게시글 작성자 ID와 페이징 정보를 전달하면, 작성자 ID 해당되는 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenSearchValueAndPageable_whenFindByUserIdContaining_thenReturnsMatchingArticles() {
+        // Given
+        String searchValue = "user1";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When
+        Page<Article> result = sut.findByUserAccount_UserIdContaining(searchValue, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(article -> article.getUserAccount().getUserId())
+                .allMatch(userId -> userId.contains(searchValue));
+    }
+
+    @DisplayName("게시글 작성자 닉네임과 페이징 정보를 전달하면, 작성자 닉네임에 해당되는 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenSearchValueAndPageable_whenFindByUserNicknameContaining_thenReturnsMatchingArticles() {
+        // Given
+        String searchValue = "별빛1";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When
+        Page<Article> result = sut.findByUserAccount_NicknameContaining(searchValue, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(article -> article.getUserAccount().getNickname())
+                .allMatch(nickname -> nickname.contains(searchValue));
+    }
+
+    @DisplayName("해시태그명들과 페이징 정보를 전달하면, 해시태그명에 해당되는 게시글을 페이지 단위로 조회할 수 있다")
+    @Test
+    void givenSearchValueAndPageable_whenFindByHashtagNames_thenReturnsMatchingArticles() {
+        // Given
+        Set<String> hashtags = Set.of("java");
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When
+        Page<Article> result = sut.findByHashtagNames(hashtags, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent())
+                .flatExtracting(Article::getArticleHashtags)
+                .extracting(articleHashtag -> articleHashtag.getHashtag().getHashtagName())
+                .anyMatch(hashtags::contains);
+    }
+
+    @DisplayName("게시글을 전달하면, DB에 저장한다")
+    @Test
+    void givenArticle_whenSave_thenReturnsSavedArticle() {
+        // Given
+        Article article = ArticleMockDataFactory.createDBArticle();
+
+        // When
+        Article result = sut.save(article);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(article);
+        assertThat(sut.findById(result.getId())).contains(result);
+    }
+
+    @DisplayName("게시글 ID를 전달하면, DB에 삭제한다")
+    @Test
+    void givenArticleId_whenDeleteById_thenArticleIsDeleted() {
+        // Given
+        Long articleId = 1L;
+
+        // When
+        sut.deleteById(articleId);
+
+        // Then
+        assertThat(sut.findById(articleId)).isNotPresent();
+    }
+
+}

--- a/src/test/java/com/back/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/back/repository/ArticleRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.back.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 
 import com.back.config.TestJpaConfig;
 import com.back.domain.Article;
@@ -19,9 +21,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 
 @DisplayName("Repository - 게시글")
-@Sql(scripts = "/sql/data.sql")
+@Sql(scripts = "/sql/data.sql", executionPhase = BEFORE_TEST_CLASS)
 @Import(TestJpaConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = BEFORE_CLASS)
 @DataJpaTest
 class ArticleRepositoryTest {
 

--- a/src/test/java/com/back/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/back/repository/HashtagRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.back.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.back.config.TestJpaConfig;
+import com.back.domain.Hashtag;
+import com.back.domain.HashtagMockDataFactory;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("Repository - 해시태그")
+@Sql(scripts = "/sql/data.sql")
+@Import(TestJpaConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DataJpaTest
+class HashtagRepositoryTest {
+
+    @Autowired
+    private HashtagRepository sut;
+
+    @DisplayName("해시태그명을 전달하면, 해당되는 해시태그 엔티티를 조회할 수 있다")
+    @Test
+    void givenHashtagNames_whenFindByHashtagNameIn_thenReturnsMatchingHashtags() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "jpa");
+
+        // When
+        Set<Hashtag> result = sut.findByHashtagNameIn(hashtagNames);
+
+        // Then
+        assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(Hashtag::getHashtagName)
+                .anyMatch(hashtagNames::contains);
+    }
+
+    @DisplayName("N개의 해시태그엔티티를 전달하면, DB에 저장된다.")
+    @Test
+    void givenHashtags_whenSaveAll_thenHashtagIsSaved() {
+        // Given
+        Set<String> hashtagNames = Set.of("test1", "test2");
+        Set<Hashtag> hashtags = hashtagNames.stream()
+                .map(HashtagMockDataFactory::createHashtagFromHashtagName)
+                .collect(Collectors.toSet());
+
+        // When
+        sut.saveAll(hashtags);
+
+        // Then
+        Set<Hashtag> savedHashtags = sut.findByHashtagNameIn(hashtagNames);
+        assertThat(savedHashtags).isNotEmpty();
+        assertThat(savedHashtags).hasSize(2);
+        assertThat(savedHashtags)
+                .extracting(Hashtag::getHashtagName)
+                .anyMatch(hashtagNames::contains);
+    }
+
+}

--- a/src/test/java/com/back/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/back/repository/HashtagRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.back.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 
 import com.back.config.TestJpaConfig;
 import com.back.domain.Hashtag;
@@ -16,9 +18,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 
 @DisplayName("Repository - 해시태그")
-@Sql(scripts = "/sql/data.sql")
+@Sql(scripts = "/sql/data.sql", executionPhase = BEFORE_TEST_CLASS)
 @Import(TestJpaConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = BEFORE_CLASS)
 @DataJpaTest
 class HashtagRepositoryTest {
 

--- a/src/test/java/com/back/repository/UserAccountRepositoryTest.java
+++ b/src/test/java/com/back/repository/UserAccountRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.back.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 
 import com.back.config.TestJpaConfig;
 import com.back.domain.UserAccount;
@@ -13,12 +15,13 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
 
 @DisplayName("Repository - 회원")
-@Sql(scripts = "/sql/data.sql")
+@Sql(scripts = "/sql/data.sql", executionPhase = BEFORE_TEST_CLASS)
 @Import(TestJpaConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = BEFORE_CLASS)
 @DataJpaTest
 class UserAccountRepositoryTest {
 

--- a/src/test/java/com/back/repository/UserAccountRepositoryTest.java
+++ b/src/test/java/com/back/repository/UserAccountRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.back.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.back.config.TestJpaConfig;
+import com.back.domain.UserAccount;
+import com.back.domain.UserAccountMockDataFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+
+
+@DisplayName("Repository - 회원")
+@Sql(scripts = "/sql/data.sql")
+@Import(TestJpaConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DataJpaTest
+class UserAccountRepositoryTest {
+
+    @Autowired
+    private UserAccountRepository sut;
+
+    @DisplayName("회원 ID를 전달하면, 해당되는 회원 엔티티를 조회할 수 있다")
+    @Test
+    void givenUserId_whenFindById_thenReturnsMatchingUser() {
+        // Given
+        String userId = "user1";
+
+        // When
+        Optional<UserAccount> result = sut.findById(userId);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getUserId()).isEqualTo(userId);
+    }
+
+    @DisplayName("회원엔티티를 전달하면, DB에 저장한다.")
+    @Test
+    void givenUser_whenSave_thenUserIsSaved() {
+        // Given
+        String userId = "test-user1";
+        UserAccount userAccount = UserAccountMockDataFactory.createDBUserAccountFromUserId(userId);
+
+        // When
+        UserAccount result = sut.save(userAccount);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(userAccount);
+        assertThat(sut.findById(result.getUserId())).contains(result);
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,5 +3,10 @@ spring:
     url: jdbc:h2:mem:my-board
   sql.init.mode: never
   jpa:
+    show-sql: true
     hibernate.ddl-auto: create
     defer-datasource-initialization: false
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:my-board
+  sql.init.mode: never
+  jpa:
+    hibernate.ddl-auto: create
+    defer-datasource-initialization: false

--- a/src/test/resources/sql/data.sql
+++ b/src/test/resources/sql/data.sql
@@ -2,114 +2,70 @@
 --- TODO: 복잡성이 커지면 추후 Test 별로 sql 파일을 분리할 수 있습니다.
 
 --- user_account
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('admin1', '{noop}qwer1234', 'admin1@naver.com', '별빛1', null, 'kakao', 'qdwd12ddd31dwd', 'ROLE_ADMIN',
-        '2015-03-17 23:20:26', 'admin1', '2010-03-05 08:28:54', 'admin1');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('user1', '{noop}qwer1234', 'user1@google.com', '아기상어5', null, null, null, 'ROLE_USER',
-        '2002-11-16 04:23:32', 'user1', '2002-11-23 04:51:37', 'user1');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('player789', '{noop}aOs420y6g', 'player789@google.com', '별빛2', null, null, null, 'ROLE_USER',
-        '2013-04-04 05:12:41',
-        'player789', '2003-09-26 15:31:56', 'player789');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('customer331', '{noop}1L1LNKfD3pvi', 'customer331@daum.com', '아기상어3', null, 'kakao', 'asdqqwddwd12dvsd',
-        'ROLE_USER',
-        '2009-01-27 20:24:30', 'customer331', '2016-12-13 12:27:53', 'customer331');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('customer341', '{noop}3Hp271Zo', 'customer341@google.com', '야구팬4', null, null, null, 'ROLE_USER',
-        '2018-10-15 01:02:14', 'customer341', '2006-03-20 14:23:55', 'customer341');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('user1234', '{noop}rTw80xiNO2as', 'user1234@google.com', '야구팬2', null, null, null, 'ROLE_USER',
-        '2009-08-14 03:31:32',
-        'user1234', '2007-01-18 11:24:26', 'user1234');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('account4256', '{noop}0C1SoS29gaD', 'account4256@google.com', '아기상어1', null, 'kakao', 'adw2d12df3vv',
-        'ROLE_USER',
-        '2009-07-16 17:59:25', 'account4256', '2013-07-06 03:53:35', 'account4256');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('customer3121', '{noop}Bp020cIHj', 'customer3121@naver.com', '달님2', null, null, null, 'ROLE_USER',
-        '2006-04-21 02:25:32', 'customer3121', '2005-12-09 05:51:55', 'customer3121');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('player7849', '{noop}7ov0AWw8F24s', 'player7849@naver.com', '별빛4', null, null, null, 'ROLE_USER',
-        '2018-06-07 13:31:11', 'player7849', '2007-06-06 10:23:12', 'player7849');
-insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
-                          created_by, modified_at, modified_by)
-values ('account4526', '{noop}ukjt0YMye', 'account4526@naver.com', '아기상어2', null, null, null, 'ROLE_USER',
-        '2015-05-05 21:44:54', 'account4526', '2018-01-30 14:20:46', 'account4526');
+insert into user_account (
+    user_id, user_password, email, nickname, memo, social_provider, social_id, role,
+    created_at, created_by, modified_at, modified_by
+) values
+      ('admin1', '{noop}qwer1234', 'admin1@naver.com', '별빛1', null, 'kakao', 'qdwd12ddd31dwd', 'ROLE_ADMIN',
+       '2015-03-17 23:20:26', 'admin1', '2010-03-05 08:28:54', 'admin1'),
+      ('user1', '{noop}qwer1234', 'user1@google.com', '아기상어5', null, null, null, 'ROLE_USER',
+       '2002-11-16 04:23:32', 'user1', '2002-11-23 04:51:37', 'user1'),
+      ('player789', '{noop}aOs420y6g', 'player789@google.com', '별빛2', null, null, null, 'ROLE_USER',
+       '2013-04-04 05:12:41', 'player789', '2003-09-26 15:31:56', 'player789'),
+      ('customer331', '{noop}1L1LNKfD3pvi', 'customer331@daum.com', '아기상어3', null, 'kakao', 'asdqqwddwd12dvsd', 'ROLE_USER',
+       '2009-01-27 20:24:30', 'customer331', '2016-12-13 12:27:53', 'customer331'),
+      ('customer341', '{noop}3Hp271Zo', 'customer341@google.com', '야구팬4', null, null, null, 'ROLE_USER',
+       '2018-10-15 01:02:14', 'customer341', '2006-03-20 14:23:55', 'customer341'),
+      ('user1234', '{noop}rTw80xiNO2as', 'user1234@google.com', '야구팬2', null, null, null, 'ROLE_USER',
+       '2009-08-14 03:31:32', 'user1234', '2007-01-18 11:24:26', 'user1234'),
+      ('account4256', '{noop}0C1SoS29gaD', 'account4256@google.com', '아기상어1', null, 'kakao', 'adw2d12df3vv', 'ROLE_USER',
+       '2009-07-16 17:59:25', 'account4256', '2013-07-06 03:53:35', 'account4256'),
+      ('customer3121', '{noop}Bp020cIHj', 'customer3121@naver.com', '달님2', null, null, null, 'ROLE_USER',
+       '2006-04-21 02:25:32', 'customer3121', '2005-12-09 05:51:55', 'customer3121'),
+      ('player7849', '{noop}7ov0AWw8F24s', 'player7849@naver.com', '별빛4', null, null, null, 'ROLE_USER',
+       '2018-06-07 13:31:11', 'player7849', '2007-06-06 10:23:12', 'player7849'),
+      ('account4526', '{noop}ukjt0YMye', 'account4526@google.com', '아기상어2', null, null, null, 'ROLE_USER',
+       '2015-05-05 21:44:54', 'account4526', '2018-01-30 14:20:46', 'account4526');
 
---- article
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('admin1', '우승 예상팀', '우승 예상팀우승 예상팀우승 예상팀우승 예상팀우승 예상팀 #java #jpa', '2005-12-14', 'admin1', '2011-07-28',
-        'admin1');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('admin1', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작 #jpa', '2008-07-06', 'admin1',
-        '2004-10-17', 'admin1');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('user1', '선수 부상 소식', '선수 부상 소식선수 부상 소식 #spring', '2019-07-28', 'user1', '2008-03-20', 'user1');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('user1', '야구 시즌 시작', '세 번째 게시글 내용', '2015-08-06', 'user1', '2012-09-25', 'user1');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('account4256', '우승 예상팀', '승 예상팀승 예상팀승 예상팀승 예상팀승 예상팀', '2016-05-03', 'account4256', '2004-02-28',
-        'account4256');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('player7849', '이적설 확인', '이적설 확인이적설 확인이적설 확인이적설 확인', '2014-07-23', 'player7849', '2001-09-12',
-        'player7849');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('player7849', '팀 승리 기록', '팀 승리 기록팀 승리 기록', '2006-04-28', 'player7849', '2001-04-30', 'player7849');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('player7849', '우승 예상팀', '우승 예상팀우승 예상팀', '2010-08-20', 'player7849', '2006-02-12', 'player7849');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작', '2014-10-30', 'player7849', '2016-06-27', 'player7849');
-insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
-values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작', '2003-08-10', 'player7849', '2008-09-28',
-        'player7849');
+insert into article (
+    user_id, title, content, created_at, created_by, modified_at, modified_by
+) values
+      ('admin1', '우승 예상팀', '우승 예상팀우승 예상팀우승 예상팀우승 예상팀우승 예상팀 #java #jpa', '2005-12-14', 'admin1', '2011-07-28', 'admin1'),
+      ('admin1', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작 #jpa', '2008-07-06', 'admin1', '2004-10-17', 'admin1'),
+      ('user1', '선수 부상 소식', '선수 부상 소식선수 부상 소식 #spring', '2019-07-28', 'user1', '2008-03-20', 'user1'),
+      ('user1', '야구 시즌 시작', '세 번째 게시글 내용', '2015-08-06', 'user1', '2012-09-25', 'user1'),
+      ('account4256', '우승 예상팀', '승 예상팀승 예상팀승 예상팀승 예상팀승 예상팀', '2016-05-03', 'account4256', '2004-02-28', 'account4256'),
+      ('player7849', '이적설 확인', '이적설 확인이적설 확인이적설 확인이적설 확인', '2014-07-23', 'player7849', '2001-09-12', 'player7849'),
+      ('player7849', '팀 승리 기록', '팀 승리 기록팀 승리 기록', '2006-04-28', 'player7849', '2001-04-30', 'player7849'),
+      ('player7849', '우승 예상팀', '우승 예상팀우승 예상팀', '2010-08-20', 'player7849', '2006-02-12', 'player7849'),
+      ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작', '2014-10-30', 'player7849', '2016-06-27', 'player7849'),
+      ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작', '2003-08-10', 'player7849', '2008-09-28', 'player7849');
 
 --- hashtag
 insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
-values ('java', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
-insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
-values ('jpa', '2007-03-13', 'admin1', '2011-05-21', 'admin1');
-insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
-values ('spring', '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+values
+    ('java', '2002-03-31', 'admin1', '2015-03-19', 'admin1'),
+    ('jpa', '2007-03-13', 'admin1', '2011-05-21', 'admin1'),
+    ('spring', '2013-06-22', 'admin1', '2020-08-04', 'admin1');
 
 --- article_hashtag
 insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
-values (1, 1, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
-insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
-values (1, 2, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
-insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
-values (2, 2, '2007-03-13', 'admin1', '2011-05-21', 'admin1');
-insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
-values (3, 3, '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+values
+    (1, 1, '2002-03-31', 'admin1', '2015-03-19', 'admin1'),
+    (1, 2, '2002-03-31', 'admin1', '2015-03-19', 'admin1'),
+    (2, 2, '2007-03-13', 'admin1', '2011-05-21', 'admin1'),
+    (3, 3, '2013-06-22', 'admin1', '2020-08-04', 'admin1');
 
 --- comment
 insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (1, 'user1', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (1, 'admin1', '야구 시즌 시작야구', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (2, 'player789', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'player789', '2015-03-19', 'player789');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (3, 'user1', '우승 예상팀우승 예상팀123', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (3, 'user1', '우승 예상팀우승 예상팀qwd', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (5, 'user1', '야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (5, 'user1', '야구 시즌 23', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (3, 'account4526', '야구 시23', '2002-03-31', 'account4526', '2015-03-19', 'account4526');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (1, 'user1', '즌 123', '2002-03-31', 'user1', '2015-03-19', 'user1');
-insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
-values (5, 'user1', '야구 시즌 시작1', '2002-03-31', 'user1', '2015-03-19', 'user1');
+values
+    (1, 'user1', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (1, 'admin1', '야구 시즌 시작야구', '2002-03-31', 'admin1', '2015-03-19', 'admin1'),
+    (2, 'player789', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'player789', '2015-03-19', 'player789'),
+    (3, 'user1', '우승 예상팀우승 예상팀123', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (3, 'user1', '우승 예상팀우승 예상팀qwd', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (5, 'user1', '야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (5, 'user1', '야구 시즌 23', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (3, 'account4526', '야구 시23', '2002-03-31', 'account4526', '2015-03-19', 'account4526'),
+    (1, 'user1', '즌 123', '2002-03-31', 'user1', '2015-03-19', 'user1'),
+    (5, 'user1', '야구 시즌 시작1', '2002-03-31', 'user1', '2015-03-19', 'user1');

--- a/src/test/resources/sql/data.sql
+++ b/src/test/resources/sql/data.sql
@@ -1,0 +1,115 @@
+--- TEST 전용 SQL 파일 입니다.
+--- TODO: 복잡성이 커지면 추후 Test 별로 sql 파일을 분리할 수 있습니다.
+
+--- user_account
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('admin1', '{noop}qwer1234', 'admin1@naver.com', '별빛1', null, 'kakao', 'qdwd12ddd31dwd', 'ROLE_ADMIN',
+        '2015-03-17 23:20:26', 'admin1', '2010-03-05 08:28:54', 'admin1');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('user1', '{noop}qwer1234', 'user1@google.com', '아기상어5', null, null, null, 'ROLE_USER',
+        '2002-11-16 04:23:32', 'user1', '2002-11-23 04:51:37', 'user1');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('player789', '{noop}aOs420y6g', 'player789@google.com', '별빛2', null, null, null, 'ROLE_USER',
+        '2013-04-04 05:12:41',
+        'player789', '2003-09-26 15:31:56', 'player789');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('customer331', '{noop}1L1LNKfD3pvi', 'customer331@daum.com', '아기상어3', null, 'kakao', 'asdqqwddwd12dvsd',
+        'ROLE_USER',
+        '2009-01-27 20:24:30', 'customer331', '2016-12-13 12:27:53', 'customer331');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('customer341', '{noop}3Hp271Zo', 'customer341@google.com', '야구팬4', null, null, null, 'ROLE_USER',
+        '2018-10-15 01:02:14', 'customer341', '2006-03-20 14:23:55', 'customer341');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('user1234', '{noop}rTw80xiNO2as', 'user1234@google.com', '야구팬2', null, null, null, 'ROLE_USER',
+        '2009-08-14 03:31:32',
+        'user1234', '2007-01-18 11:24:26', 'user1234');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('account4256', '{noop}0C1SoS29gaD', 'account4256@google.com', '아기상어1', null, 'kakao', 'adw2d12df3vv',
+        'ROLE_USER',
+        '2009-07-16 17:59:25', 'account4256', '2013-07-06 03:53:35', 'account4256');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('customer3121', '{noop}Bp020cIHj', 'customer3121@naver.com', '달님2', null, null, null, 'ROLE_USER',
+        '2006-04-21 02:25:32', 'customer3121', '2005-12-09 05:51:55', 'customer3121');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('player7849', '{noop}7ov0AWw8F24s', 'player7849@naver.com', '별빛4', null, null, null, 'ROLE_USER',
+        '2018-06-07 13:31:11', 'player7849', '2007-06-06 10:23:12', 'player7849');
+insert into user_account (user_id, user_password, email, nickname, memo, social_provider, social_id, role, created_at,
+                          created_by, modified_at, modified_by)
+values ('account4526', '{noop}ukjt0YMye', 'account4526@naver.com', '아기상어2', null, null, null, 'ROLE_USER',
+        '2015-05-05 21:44:54', 'account4526', '2018-01-30 14:20:46', 'account4526');
+
+--- article
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('admin1', '우승 예상팀', '우승 예상팀우승 예상팀우승 예상팀우승 예상팀우승 예상팀 #java #jpa', '2005-12-14', 'admin1', '2011-07-28',
+        'admin1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('admin1', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작야구 시즌 시작 #jpa', '2008-07-06', 'admin1',
+        '2004-10-17', 'admin1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('user1', '선수 부상 소식', '선수 부상 소식선수 부상 소식 #spring', '2019-07-28', 'user1', '2008-03-20', 'user1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('user1', '야구 시즌 시작', '세 번째 게시글 내용', '2015-08-06', 'user1', '2012-09-25', 'user1');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('account4256', '우승 예상팀', '승 예상팀승 예상팀승 예상팀승 예상팀승 예상팀', '2016-05-03', 'account4256', '2004-02-28',
+        'account4256');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '이적설 확인', '이적설 확인이적설 확인이적설 확인이적설 확인', '2014-07-23', 'player7849', '2001-09-12',
+        'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '팀 승리 기록', '팀 승리 기록팀 승리 기록', '2006-04-28', 'player7849', '2001-04-30', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '우승 예상팀', '우승 예상팀우승 예상팀', '2010-08-20', 'player7849', '2006-02-12', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작', '2014-10-30', 'player7849', '2016-06-27', 'player7849');
+insert into article (user_id, title, content, created_at, created_by, modified_at, modified_by)
+values ('player7849', '야구 시즌 시작', '야구 시즌 시작야구 시즌 시작야구 시즌 시작', '2003-08-10', 'player7849', '2008-09-28',
+        'player7849');
+
+--- hashtag
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('java', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('jpa', '2007-03-13', 'admin1', '2011-05-21', 'admin1');
+insert into hashtag (hashtag_name, created_at, created_by, modified_at, modified_by)
+values ('spring', '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+
+--- article_hashtag
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (1, 1, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (1, 2, '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (2, 2, '2007-03-13', 'admin1', '2011-05-21', 'admin1');
+insert into article_hashtag (article_id, hashtag_id, created_at, created_by, modified_at, modified_by)
+values (3, 3, '2013-06-22', 'admin1', '2020-08-04', 'admin1');
+
+--- comment
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'user1', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'admin1', '야구 시즌 시작야구', '2002-03-31', 'admin1', '2015-03-19', 'admin1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (2, 'player789', '야구 시즌 시작야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'player789', '2015-03-19', 'player789');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'user1', '우승 예상팀우승 예상팀123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'user1', '우승 예상팀우승 예상팀qwd', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 시작야구 시즌 시작123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 23', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (3, 'account4526', '야구 시23', '2002-03-31', 'account4526', '2015-03-19', 'account4526');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (1, 'user1', '즌 123', '2002-03-31', 'user1', '2015-03-19', 'user1');
+insert into comment (article_id, user_id, content, created_at, created_by, modified_at, modified_by)
+values (5, 'user1', '야구 시즌 시작1', '2002-03-31', 'user1', '2015-03-19', 'user1');


### PR DESCRIPTION
## #️⃣연관된 이슈
#43 

## 📝작업 내용
- 기존 해시태그 검색 쿼리에서 count 쿼리를 별도로 수행하지 않고, 조회 결과를 가지고 페이징 처리를 하고 있었다.
  - 이 문제를 해결하기 위해 조회 쿼리 조건과 동일한 count 쿼리를  날려 데이터 개수를 가져와 페이징 처리를 하도록 수정했다.
- `QuerydslRepositorySupport` 방식에서 대중적인 `JPAQueryFactory` 방식으로 수정함. 
  - `QuerydslRepositorySupport`는 최근 버전에서 잘 사용하지 않고, 기능적 한계가 있음.
- Repository 테스트가 제대로 작성되어 있지 않아서 발생한 문제 이므로 Repository 테스트를 추가
  - 현재 모든 도메인에서 사용중인 쿼리메서드에 중점적으로 테스트를 작성함.

## ⛔️ 종료할 이슈 
This close #43
